### PR TITLE
メール送信処理を可能に修正

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -9,3 +9,15 @@ DATABASE_PASSWORD=mysql
 
 # front-endのurlを記載
 RESERVATION_CLIENT_DOMAIN=http://localhost:3000
+
+# メールの送信方式を記載 
+# smtp：実際にメールを送信する
+# letter_opener：別タブでメールの文面を表示
+MAIL_DELIVERY_METHOD=letter_opener
+
+# 各種メール設定。smtpの場合のみ、有効
+MAIL_PORT=
+MAIL_HOST=
+MAIL_ADDRESS=
+MAIL_USER=
+MAIL_PASSWORD=

--- a/src/app/controllers/api/reservations_controller.rb
+++ b/src/app/controllers/api/reservations_controller.rb
@@ -20,6 +20,7 @@ class Api::ReservationsController < Api::ApiController
       :reservation_date,
       :start_time,
       :store_id,
+      :is_first,
       coupon_ids: [],
       reservation_details_attributes: [
         :menu_id, 

--- a/src/app/controllers/api/reservations_controller.rb
+++ b/src/app/controllers/api/reservations_controller.rb
@@ -19,12 +19,12 @@ class Api::ReservationsController < Api::ApiController
       :reservation_comment,
       :reservation_date,
       :start_time,
-      :store_id,
       :is_first,
       coupon_ids: [],
       reservation_details_attributes: [
+        :store_id,
         :menu_id, 
-        :mimitsubo_count, 
+        :mimitsubo_count,
         option_ids: [],
       ]
     )

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -39,6 +39,10 @@ class CustomersController < ApplicationController
     @stores = Store.all
     @customer = Customer.new(customer_params)
 
+    # メールが送信されないようにする
+    # 下記の実装漏れによるバグ可能性が高いため、要改修
+    @customer.should_send_mail = false
+
     respond_to do |format|
       begin
         @customer.save!

--- a/src/app/mailers/application_mailer.rb
+++ b/src/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'info@olive.co.jp'
   layout 'mailer'
 end

--- a/src/app/mailers/customer_mailer.rb
+++ b/src/app/mailers/customer_mailer.rb
@@ -1,0 +1,8 @@
+class CustomerMailer < ApplicationMailer
+  def confirm_register(customer)
+    @customer = customer
+    mail(subject: '登録完了', to: @customer.email) do |format|
+      format.text
+    end
+  end
+end

--- a/src/app/mailers/devise_mailer.rb
+++ b/src/app/mailers/devise_mailer.rb
@@ -1,0 +1,3 @@
+class DeviseMailer < Devise::Mailer
+  # deviseの送信メールの文面を変更するために実装
+end

--- a/src/app/mailers/reservation_mailer.rb
+++ b/src/app/mailers/reservation_mailer.rb
@@ -1,0 +1,9 @@
+class ReservationMailer < ApplicationMailer
+  def confirm_reservation(reservation)
+    @reservation = reservation
+    @customer = reservation.customer
+    mail(subject: '予約確定', to: @customer.email) do |format|
+      format.text
+    end
+  end
+end

--- a/src/app/models/menu.rb
+++ b/src/app/models/menu.rb
@@ -38,6 +38,7 @@ class Menu < ApplicationRecord
             price: self.fee, 
             minutes: self.service_minutes,
             description: self.description,
+            department_id: self.menu_category.department_id, 
             options: options.map { |option| option.to_api_json },
         }
     end

--- a/src/app/models/option.rb
+++ b/src/app/models/option.rb
@@ -24,7 +24,7 @@ class Option < ApplicationRecord
 
   private
 
-  ACUPUNCTURE_OPTION_ID = 6
-  MIMITSUBO_JWELRY_OPTION_ID = 8
+  ACUPUNCTURE_OPTION_ID = 5
+  MIMITSUBO_JWELRY_OPTION_ID = 7
 
 end

--- a/src/app/views/customer_mailer/confirm_register.text.erb
+++ b/src/app/views/customer_mailer/confirm_register.text.erb
@@ -1,0 +1,3 @@
+<%= @customer.last_name %> 様
+
+登録完了いたしました。

--- a/src/app/views/devise_mailer/reset_password_instructions.html.erb
+++ b/src/app/views/devise_mailer/reset_password_instructions.html.erb
@@ -1,0 +1,16 @@
+<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
+
+<p><%= t('.request_reset_link_msg') %></p>
+
+<p><%= link_to(
+  t('.password_change_link'), 
+  edit_password_url(
+    @resource, 
+    reset_password_token: @token, 
+    config: message['client-config'].to_s, 
+    redirect_url: message['redirect-url'].to_s
+  ).html_safe
+) %></p>
+
+<p><%= t('.ignore_mail_msg') %></p>
+<p><%= t('.no_changes_msg') %></p>

--- a/src/app/views/reservation_mailer/confirm_reservation.text.erb
+++ b/src/app/views/reservation_mailer/confirm_reservation.text.erb
@@ -1,0 +1,3 @@
+<%= @customer.last_name %> 様
+
+予約が確定いたしました。

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -33,15 +33,14 @@ module Src
     meil_delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', 'letter_opener').to_sym
     config.action_mailer.delivery_method = meil_delivery_method
 
-    if meil_delivery_method === :stmp 
+    if meil_delivery_method === :smtp
       config.action_mailer.smtp_settings = {
         port:                 ENV.fetch('MAIL_PORT', ''),
         domain:               ENV.fetch('MAIL_HOST', ''),
         address:              ENV.fetch('MAIL_ADDRESS', ''),
         user_name:            ENV.fetch('MAIL_USER', ''),
         password:             ENV.fetch('MAIL_PASSWORD', ''),
-        authentication:       'login',
-        enable_starttls_auto: true
+        authentication:       ENV.fetch('MAIL_AUTH', 'login').to_sym,
       }
     end
     

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -28,6 +28,23 @@ module Src
       end
     end
     
+    config.action_mailer.raise_delivery_errors = true
+    
+    meil_delivery_method = Env.fetch('MAIL_DELIVERY_METHOD', 'letter_opener').to_sym
+    config.action_mailer.delivery_method = meil_delivery_method
+
+    if meil_delivery_method === :stmp 
+      config.action_mailer.smtp_settings = {
+        port:                 Env.fetch('MAIL_PORT', ''),
+        domain:               Env.fetch('MAIL_HOST', ''),
+        address:              Env.fetch('MAIL_ADDRESS', ''),
+        user_name:            Env.fetch('MAIL_USER', ''),
+        password:             Env.fetch('MAIL_PASSWORD', ''),
+        authentication:       'login',
+        enable_starttls_auto: true
+      }
+    end
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -30,16 +30,16 @@ module Src
     
     config.action_mailer.raise_delivery_errors = true
     
-    meil_delivery_method = Env.fetch('MAIL_DELIVERY_METHOD', 'letter_opener').to_sym
+    meil_delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', 'letter_opener').to_sym
     config.action_mailer.delivery_method = meil_delivery_method
 
     if meil_delivery_method === :stmp 
       config.action_mailer.smtp_settings = {
-        port:                 Env.fetch('MAIL_PORT', ''),
-        domain:               Env.fetch('MAIL_HOST', ''),
-        address:              Env.fetch('MAIL_ADDRESS', ''),
-        user_name:            Env.fetch('MAIL_USER', ''),
-        password:             Env.fetch('MAIL_PASSWORD', ''),
+        port:                 ENV.fetch('MAIL_PORT', ''),
+        domain:               ENV.fetch('MAIL_HOST', ''),
+        address:              ENV.fetch('MAIL_ADDRESS', ''),
+        user_name:            ENV.fetch('MAIL_USER', ''),
+        password:             ENV.fetch('MAIL_PASSWORD', ''),
         authentication:       'login',
         enable_starttls_auto: true
       }

--- a/src/config/environments/development.rb
+++ b/src/config/environments/development.rb
@@ -62,5 +62,8 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { 
+    host: 'localhost', 
+    port: 8080 
+  }
 end

--- a/src/config/initializers/devise.rb
+++ b/src/config/initializers/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'DeviseMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/src/db/migrate/20190116151224_create_departments.rb
+++ b/src/db/migrate/20190116151224_create_departments.rb
@@ -1,4 +1,4 @@
-class CreateDepartmentCategories < ActiveRecord::Migration[5.1]
+class CreateDepartments < ActiveRecord::Migration[5.1]
   def change
     create_table :departments do |t|
       t.string :name

--- a/src/db/migrate/20190119034234_create_reservations.rb
+++ b/src/db/migrate/20190119034234_create_reservations.rb
@@ -12,6 +12,8 @@ class CreateReservations < ActiveRecord::Migration[5.1]
       t.time :start_time
       t.time :end_time
 
+      t.boolean :is_first
+
       t.date :deleted_at
       t.timestamps
     end

--- a/src/db/migrate/20190119034234_create_reservations.rb
+++ b/src/db/migrate/20190119034234_create_reservations.rb
@@ -4,7 +4,6 @@ class CreateReservations < ActiveRecord::Migration[5.1]
       t.integer :children_count, default: 0, comment: '随伴するお子様の数'
       t.text :reservation_comment
       
-      t.references :store, foreign_key: true, on_delete: :cascade
       t.references :customer, foreign_key: true, on_delete: :cascade
       t.references :pregnant_state, null: true, default: nil, foreign_key: true
       
@@ -13,7 +12,6 @@ class CreateReservations < ActiveRecord::Migration[5.1]
       t.time :end_time
 
       t.boolean :is_first
-
       t.date :deleted_at
       t.timestamps
     end

--- a/src/db/migrate/20190414154725_create_reservation_details.rb
+++ b/src/db/migrate/20190414154725_create_reservation_details.rb
@@ -3,8 +3,8 @@ class CreateReservationDetails < ActiveRecord::Migration[5.1]
     create_table :reservation_details, comment: '予約の詳細。シフトやメニューなどに紐づく' do |t|
       t.references :reservation, on_delete: :cascade, foreign_key: true
       t.references :menu, on_delete: :nullify, foreign_key: true
+      t.references :store, foreign_key: true, on_delete: :cascade
       t.integer :mimitsubo_count, comment: '耳つぼジュエリの個数。'
-
       t.timestamps
     end
   end

--- a/src/db/migrate/20190417075237_devise_token_auth_create_customers.rb
+++ b/src/db/migrate/20190417075237_devise_token_auth_create_customers.rb
@@ -3,6 +3,7 @@ class DeviseTokenAuthCreateCustomers < ActiveRecord::Migration[5.2]
     add_column :customers, :provider, :string, null: false, default: 'email', comment: '非会員の場合、noneになる'
     add_column :customers, :uid, :string, null: false, default: ''
     add_column :customers, :tokens, :text
+    add_column :customers, :allow_password_change, :boolean, default: false, comment: 'パスワード変更に必要'
 
     Customer.reset_column_information
     add_index :customers, [:uid, :provider], unique: true

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -200,6 +200,7 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
     t.date "reservation_date"
     t.time "start_time"
     t.time "end_time"
+    t.boolean "is_first"
     t.date "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
     t.string "provider", default: "email", null: false, comment: "非会員の場合、noneになる"
     t.string "uid", default: "", null: false
     t.text "tokens"
+    t.boolean "allow_password_change", default: false, comment: "パスワード変更に必要"
     t.index ["baby_age_id"], name: "index_customers_on_baby_age_id"
     t.index ["email"], name: "index_customers_on_email"
     t.index ["first_visit_store_id"], name: "index_customers_on_first_visit_store_id"

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -175,11 +175,13 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
   create_table "reservation_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "予約の詳細。シフトやメニューなどに紐づく", force: :cascade do |t|
     t.bigint "reservation_id"
     t.bigint "menu_id"
+    t.bigint "store_id"
     t.integer "mimitsubo_count", comment: "耳つぼジュエリの個数。"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["menu_id"], name: "index_reservation_details_on_menu_id"
     t.index ["reservation_id"], name: "index_reservation_details_on_reservation_id"
+    t.index ["store_id"], name: "index_reservation_details_on_store_id"
   end
 
   create_table "reservation_shifts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -194,7 +196,6 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
   create_table "reservations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "children_count", default: 0, comment: "随伴するお子様の数"
     t.text "reservation_comment"
-    t.bigint "store_id"
     t.bigint "customer_id"
     t.bigint "pregnant_state_id"
     t.date "reservation_date"
@@ -206,7 +207,6 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_reservations_on_customer_id"
     t.index ["pregnant_state_id"], name: "index_reservations_on_pregnant_state_id"
-    t.index ["store_id"], name: "index_reservations_on_store_id"
   end
 
   create_table "roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -332,11 +332,11 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
   add_foreign_key "reservation_detail_options", "reservation_details"
   add_foreign_key "reservation_details", "menus"
   add_foreign_key "reservation_details", "reservations"
+  add_foreign_key "reservation_details", "stores"
   add_foreign_key "reservation_shifts", "reservations"
   add_foreign_key "reservation_shifts", "shifts"
   add_foreign_key "reservations", "customers"
   add_foreign_key "reservations", "pregnant_states"
-  add_foreign_key "reservations", "stores"
   add_foreign_key "shifts", "staffs"
   add_foreign_key "shifts", "stores"
   add_foreign_key "skill_staffs", "skills"

--- a/src/db/seeds/store_menu_seeds.rb
+++ b/src/db/seeds/store_menu_seeds.rb
@@ -32,17 +32,15 @@ Menu.where(id: 17).first_or_create!(name:'エレガントプラン', skill_id: 1
 Menu.where(id: 18).first_or_create!(name:'デラックスプラン', skill_id: 1, fee:90000, service_minutes:0, start_at:'2019-01-01', menu_category_id:6)
 Menu.where(id: 19).first_or_create!(name:'ラグジュアリープラン', skill_id: 1, fee:126000, service_minutes:0, start_at:'2019-01-01', menu_category_id:6)
 
-Option.where(id: 1).first_or_create!(name:'初診・問診', skill_id: 1, fee:1000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 2).first_or_create!(name:'足つぼ', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 3).first_or_create!(name:'小顔矯正', skill_id: 1, fee:4000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 4).first_or_create!(name:'テーピング', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 5).first_or_create!(name:'インデプス', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 6).first_or_create!(name:'本治療', skill_id: 2, fee:2000, start_at:'2019-01-01', department_id:1, description: '鍼のオプションのため、鍼につけることはできない')
-Option.where(id: 7).first_or_create!(name:'耳つぼ', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 8).first_or_create!(name:'耳つぼジュエリー', skill_id: 1, fee:500, start_at:'2019-01-01', department_id:1)
-Option.where(id: 9).first_or_create!(name:'赤ちゃん鍼', skill_id: 2, fee:1000, start_at:'2019-01-01', department_id:1)
-Option.where(id: 10).first_or_create!(name:'置鍼', skill_id: 2, fee:300, start_at:'2019-01-01', department_id:1)
-Option.where(id: 11).first_or_create!(name:'初回カウンセリング', skill_id: 1, fee:1000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 1).first_or_create!(name:'足つぼ', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 2).first_or_create!(name:'小顔矯正', skill_id: 1, fee:4000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 3).first_or_create!(name:'テーピング', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 4).first_or_create!(name:'インデプス', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 5).first_or_create!(name:'本治療', skill_id: 2, fee:2000, start_at:'2019-01-01', department_id:1, description: '鍼のオプションのため、鍼につけることはできない')
+Option.where(id: 6).first_or_create!(name:'耳つぼ', skill_id: 1, fee:2000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 7).first_or_create!(name:'耳つぼジュエリー', skill_id: 1, fee:500, start_at:'2019-01-01', department_id:1)
+Option.where(id: 8).first_or_create!(name:'赤ちゃん鍼', skill_id: 2, fee:1000, start_at:'2019-01-01', department_id:1)
+Option.where(id: 9).first_or_create!(name:'置鍼', skill_id: 2, fee:300, start_at:'2019-01-01', department_id:1)
 
 Store.where(id: 1).first_or_create!(
   store_type: 0,

--- a/src/db/seeds/store_menu_seeds.rb
+++ b/src/db/seeds/store_menu_seeds.rb
@@ -7,12 +7,11 @@ MenuCategory.where(id: 3).first_or_create!(name:'交通事故治療', department
 MenuCategory.where(id: 4).first_or_create!(name:'不妊治療', department_id:1)
 MenuCategory.where(id: 5).first_or_create!(name:'エステ', department_id:2)
 MenuCategory.where(id: 6).first_or_create!(name:'ブライダルエステ', department_id:2)
-MenuCategory.where(id: 7).first_or_create!(name:'オプション', department_id:1)
 
 Skill.where(id: 1).first_or_create!(name:'柔道整体師')
 Skill.where(id: 2).first_or_create!(name:'鍼灸師')
 
-Menu.where(id: 1).first_or_create!(name:'初通常整体コース', skill_id: 1, fee:6000, service_minutes:60, start_at:'2019-01-01', menu_category_id:1)
+Menu.where(id: 1).first_or_create!(name:'通常整体コース', skill_id: 1, fee:6000, service_minutes:60, start_at:'2019-01-01', menu_category_id:1)
 Menu.where(id: 2).first_or_create!(name:'整体スペシャルパックコース', skill_id: 1, fee:25000, service_minutes:120, start_at:'2019-01-01', menu_category_id:1)
 Menu.where(id: 3).first_or_create!(name:'骨盤矯正', skill_id: 1, fee:6000, service_minutes:60, start_at:'2019-01-01', menu_category_id:1)
 Menu.where(id: 4).first_or_create!(name:'マッサージ', skill_id: 1, fee:6000, service_minutes:60, start_at:'2019-01-01', menu_category_id:1)


### PR DESCRIPTION
# 対応内容
## メール設定
- config, envからメール設定を可能に修正
- 管理画面からの操作の場合、メールを送信しないように修正
- 各メールのロジック、文面の実装
- メール文に記載するドメインをlocalhost:8080に固定する

## api
- パラメータの形式修正
- 初回フラグを登録可能に修正

## seed
- 不要なマスタの削除
- 初回オプションが消えたので、idを修正