### PR TITLE
予約を取得可能に修正

### DIFF
--- a/src/app/controllers/api/reservations_controller.rb
+++ b/src/app/controllers/api/reservations_controller.rb
@@ -16,9 +16,10 @@ class Api::ReservationsController < Api::ApiController
       .paginate(index_params[:page])
       .order_reserved_at
 
+    # total_pages > data の順にキーを配置しなければ、エラーになる可能性あり
     render json: { 
-      data: reservations,
-      total_pages: reservations.total_pages
+      total_pages: reservations.total_pages,
+      data: reservations.to_resources,
     }
   end
 

--- a/src/app/models/reservation.rb
+++ b/src/app/models/reservation.rb
@@ -5,7 +5,7 @@ class Reservation < ApplicationRecord
   serialize :start_time, Tod::TimeOfDay
   serialize :end_time, Tod::TimeOfDay
 
-  acts_as_paranoid
+  acts_as_paranoid column: :canceled_at
 
   extend DateModule
   include PaginationModule
@@ -33,9 +33,31 @@ class Reservation < ApplicationRecord
     .order(start_time: :desc)	
   }
 
+  def self.to_resources
+    return self.all.map { |reservation| reservation.to_resource }
+  end
+
+  def to_resource
+    reservation_detail = self.reservation_details.first
+    return {
+      id: self.id,
+      state: self.state,
+      store: reservation_detail.store,
+      start_at: self.start_time.on(self.reservation_date),
+      end_at: self.end_time.on(self.reservation_date),
+      menu: reservation_detail.menu,
+      fee: self.total_fee,
+    }
+  end
+
   def build_shifts
     self.end_time = extract_end_time_from_details
-    shifts = Shift.where(date: self.reservation_date).where(start_at: (self.start_time.to_s)...(self.end_time.to_s)).where(staff_id: extract_can_treat_staff_ids).where_not_reserved.group_by { |shift| shift.staff_id }
+    shifts = Shift
+      .where(date: self.reservation_date)
+      .where(start_at: (self.start_time.to_s)...(self.end_time.to_s))
+      .where(staff_id: extract_can_treat_staff_ids)
+      .where_not_reserved
+      .group_by { |shift| shift.staff_id }
       .select { |staff_id, shifts| shifts.length === necessary_shift_count }
       .values
       .first
@@ -47,14 +69,20 @@ class Reservation < ApplicationRecord
   end
 
   def total_fee
-    self.reservation_details.sum { |detail|
-      detail.total_fee
-    }
+    return self.reservation_details.sum { |detail| detail.total_fee }
   end
 
   def necessary_shift_count
     reserved_duration = Tod::Shift.new(self.start_time, self.end_time).duration
     return reserved_duration / Shift::SLOT_INCREMENT_MITUNES.minutes.seconds
+  end
+
+  def state
+    return 'キャンセル' if self.deleted?
+
+    reservation_end_at = self.end_time.on(self.reservation_date)
+    visited = reservation_end_at < DateTime.now
+    return visited ? '来店済み' : '予約中'
   end
   
   private

--- a/src/app/views/customers/show.html.erb
+++ b/src/app/views/customers/show.html.erb
@@ -4,7 +4,7 @@
 <table class="table">
 	<thead class="thead-light">
 		<tr>
-			<th scope="col">キャンセル有無</th>
+			<th scope="col">ステータス</th>
 			<th scope="col">予約日時</th>
 			<th scope="col">担当者</th>
 			<th scope="col">売上金額</th>
@@ -18,7 +18,7 @@
 		<% @reservations.each do |reservation| %>
 			<% row_span = reservation.reservation_details.count %>
 			<tr>
-				<td rowspan="<%= row_span %>"><%= (reservation.deleted_at) ? "有" : "無" %></td>
+				<td rowspan="<%= row_span %>"><%= reservation.state %></td>
 				<td rowspan="<%= row_span %>">
 					<%= reservation.reservation_date %>&nbsp;
 					<%= reservation.start_time.strftime("%H:%M") %>〜<%= reservation.end_time.strftime("%H:%M") %>

--- a/src/db/migrate/20190119034234_create_reservations.rb
+++ b/src/db/migrate/20190119034234_create_reservations.rb
@@ -13,7 +13,7 @@ class CreateReservations < ActiveRecord::Migration[5.1]
       t.time :end_time
 
       t.boolean :is_first
-      t.date :deleted_at, comment: 'キャンセルされた日時。paranoidを利用しているため、このように命名'
+      t.date :canceled_at, comment: 'キャンセルされた日時'
       t.timestamps
     end
   end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -44,7 +44,8 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
     t.string "last_name"
     t.string "first_kana"
     t.string "last_kana"
-    t.string "tel"
+    t.string "tel", comment: "携帯電話番号"
+    t.string "foxed_line_tel", comment: "固定電話番号"
     t.string "pc_mail", comment: "pcメール。fileMakerから移行"
     t.string "phone_mail", comment: "携帯メール。fileMakerから移行"
     t.boolean "can_receive_mail", default: true, comment: "お知らせメールなどの受け取り可否"
@@ -204,7 +205,7 @@ ActiveRecord::Schema.define(version: 2019_04_20_014643) do
     t.time "start_time"
     t.time "end_time"
     t.boolean "is_first"
-    t.date "deleted_at", comment: "キャンセルされた日時。paranoidを利用しているため、このように命名"
+    t.date "canceled_at", comment: "キャンセルされた日時"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_reservations_on_customer_id"


### PR DESCRIPTION
# 対応内容
## 削除フラグをcanceled_atに修正
- migrationの修正
- 画面の修正

## 予約にステータス属性を追加
- キャンセルか、来店済みか
- 後ほど、修正予定

## apiのjsonを修正
- フロントにあわせて、修正