### PR TITLE
スタッフフォームの修正

### DIFF
--- a/src/app/models/staff.rb
+++ b/src/app/models/staff.rb
@@ -9,6 +9,7 @@ class Staff < ApplicationRecord
   has_many :skill_staff
   has_many :skills, through: :skill_staff
   accepts_nested_attributes_for :skill_staff, update_only: true
+  validates :skill_staff, presence: true
 
   belongs_to :store
   belongs_to :role

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form-wrapper">
-    <%= simple_form_for(@customer, wrapper: :horizontal_form, html: { class: 'form-horizontal' }) do |f|%>
+    <%= simple_form_for(@customer, wrapper: :horizontal_form, html: { class: 'form-horizontal', autocomplete: 'off' }) do |f|%>
     <%= f.error_notification %>
     <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
@@ -15,8 +15,8 @@
         <%= f.input :tel, label: '電話番号', required: @customer.new_record? %>
         <%= f.input :fixed_line_tel, label: '固定電話番号' %>
         <%= f.input :phone_mail, label: '携帯メールアドレス' %>
-        <%= f.input :pc_mail, label: 'PCメールアドレス'%>
-        <%= f.input :email, label: 'メールアドレス(会員ID)'%>
+        <%= f.input :pc_mail, label: 'PCメールアドレス' %>
+        <%= f.input :email, label: 'メールアドレス(会員ID)' %>
         <%= f.input(
             :can_receive_mail, 
             as: :radio_buttons, 
@@ -39,9 +39,9 @@
             label: '直近ご来店店舗', 
             default: @customer.last_visit_store_id 
         ) %>
-        <%= f.input :comment, label: 'コメント'%>
-        <%= f.input :zip_code, label: '郵便番号(XXX-XXXX)'%>
-        <%= f.input :address, label: '住所'%>
+        <%= f.input :comment, label: 'コメント' %>
+        <%= f.input :zip_code, label: '郵便番号(XXX-XXXX)' %>
+        <%= f.input :address, label: '住所' %>
         <%= f.input(
             :birthday, 
             label: '生年月日', 
@@ -60,8 +60,8 @@
             hint: '会員にする場合、メールアドレス(会員ID)とパスワードの入力が必須になります', 
             collection: { '非会員' => :none, '会員' => :email } 
         ) %>
-        <%= f.input :password, label: 'パスワード'%>
-        <%= f.button :submit, class: 'btn btn-primary'%>
+        <%= f.input :password, label: 'パスワード' %>
+        <%= f.button :submit, class: 'btn btn-primary' %>
         <%= link_to '戻る', customers_path, class: 'btn btn-light' %>
         <% end %>
     </div>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -47,7 +47,8 @@
             label: '生年月日', 
             wrapper: :horizontal_multi_select, 
             start_year: 1940, 
-            end_year: Date.today.year
+            end_year: Date.today.year,
+            include_blank: true
         ) %>
         <% if @customer.persisted? %>
             <%= f.input :age, label: '年齢', readonly: true %>

--- a/src/app/views/staffs/_form.html.erb
+++ b/src/app/views/staffs/_form.html.erb
@@ -14,21 +14,25 @@
 
     <div class="form-center">
       <%= f.input :store_id, as: :select, collection: @stores.map{|store| [store.name, store.id]}, label: '所属店舗', default: @staff.store_id%>
-      <%= f.input :last_name, label: '姓', required: true%>
-      <%= f.input :first_name, label: '名', required: true%>
-      <%= f.input :last_kana, label: 'セイ', required: true%>
-      <%= f.input :first_kana, label: 'メイ', required: true%>
-      <%= f.input :skill_ids, as: :check_boxes, wrapper: :horizontal_collection_inline,
-              collection: @skills.map{|skill| [skill.name, skill.id]}, label: '保有スキル',
-              checked: @staff_skills.present? ? @staff_skills.map{|item| item.skill_id} : [], include_hidden: false%>
+      <%= f.input :last_name, label: '姓', required: true %>
+      <%= f.input :first_name, label: '名', required: true %>
+      <%= f.input :last_kana, label: 'セイ', required: true %>
+      <%= f.input :first_kana, label: 'メイ', required: true %>
+      <%= f.input(
+        :skill_ids,
+        as: :check_boxes,
+        wrapper: :horizontal_collection_inline,
+        collection: @skills.map{|skill| [skill.name, skill.id]},
+        label: '保有スキル',
+        checked: @staff_skills.present? ? @staff_skills.map{|item| item.skill_id} : [],
+        include_hidden: false
+      ) %>
       <%= f.input :employment_type, as: :select, label: '雇用区分', collection: Settings.employment_type.map.with_index{|name, id| [name, id]}, default: @staff.employment_type%>
       <% if request.path_info != new_staff_path || current_staff.role_id == 1%>
-      <%= f.input :role_id, as: :select, collection: @roles.map{|role| [role.name, role.id]}, label: 'システム利用権限', default: 0%>
+        <%= f.input :role_id, as: :select, collection: @roles.map{|role| [role.name, role.id]}, label: 'システム利用権限', default: 0%>
       <%end%>
-      <% if request.path_info == new_staff_path%>
-      <%=f.input :login, label: "ログインID"%>
-      <%=f.input :password, label: "パスワード"%>
-      <%end%>
+      <%= f.input :login, label: "ログインID", required: true %>
+      <%= f.input :password, label: "パスワード", required: @staff.new_record? %>
       <div>
         <%= f.button :submit, class: 'btn btn-primary'%>
         <%= link_to '戻る', staffs_path, class: 'btn btn-light' %>

--- a/src/db/seeds/store_menu_seeds.rb
+++ b/src/db/seeds/store_menu_seeds.rb
@@ -67,12 +67,9 @@ Store.where(id: 2).first_or_create!(
 
 Menu.all.each do |menu|
   store_id = menu.id < 11 ? 1 : 2
-  StoreMenu.where(store_id: store_id, menu_id: menu.id).first_or_create!
-  StoreMenu.where(store_id: 3, menu_id: menu.id).first_or_create!
-  
+  StoreMenu.where(store_id: store_id, menu_id: menu.id).first_or_create!  
 end
 
 Option.all.each do |option|
   StoreOption.where(store_id: 1, option_id: option.id).first_or_create!
-  StoreOption.where(store_id: 3, option_id: option.id).first_or_create!
 end

--- a/src/db/seeds/test/20190426_initial_staff_seeds.rb
+++ b/src/db/seeds/test/20190426_initial_staff_seeds.rb
@@ -7,6 +7,8 @@ staff.update_attributes!(
   store_id: 1,
   first_name: '管理者', 
   last_name: 'オリーブ',
+  first_kana: 'カンリシャ', 
+  last_kana: 'オリーブ',
   login: 'test',
   password: 'password'
 )


### PR DESCRIPTION
# 対応概要
## スタッフが登録できない件
- フォームを修正
　- 本来、jsでやるべきなので、後ほどリファクタリング予定？
- 入力パスワードが空ならパラムから除く処理を修正

## スタッフの必須項目追加
- 必須項目を追加
- 保有スキルのみ、コントローラ側でバリデーションをかける
　- htmlに当該機能が存在しないため