### PR TITLE
予約と店舗を一対一に修正する

### DIFF
--- a/src/app/controllers/api/reservations_controller.rb
+++ b/src/app/controllers/api/reservations_controller.rb
@@ -42,6 +42,7 @@ class Api::ReservationsController < Api::ApiController
   def reservation_params
     params.permit(
       :customer_id,
+      :store_id,
       :pregnant_state_id,
       :children_count,
       :reservation_comment,
@@ -50,7 +51,6 @@ class Api::ReservationsController < Api::ApiController
       :is_first,
       coupon_ids: [],
       reservation_details_attributes: [
-        :store_id,
         :menu_id, 
         :mimitsubo_count,
         option_ids: [],

--- a/src/app/controllers/reservations_controller.rb
+++ b/src/app/controllers/reservations_controller.rb
@@ -91,6 +91,7 @@ class ReservationsController < ApplicationController
       params.require(:reservation).permit(
         :id,
         :customer_id,
+        :store_id,
         :reservation_date,
         :start_time,
         :end_time,
@@ -100,7 +101,6 @@ class ReservationsController < ApplicationController
         :is_first,
         reservation_details_attributes: [
           :id,
-          :store_id,
           :menu_id, 
           :mimitsubo_count,
           option_ids: [],

--- a/src/app/views/reservations/_form.html.erb
+++ b/src/app/views/reservations/_form.html.erb
@@ -11,6 +11,7 @@
 		hint: '予約登録時は空いているスタッフが自動補完されます',
 		disabled: @reservation.new_record?
 	) %>
+	<%= f.input :store_id, collection: Store.all, label: '予約店舗', required: true %>
 	<%= f.input :reservation_date, label: "予約日", required: true %>
 	<%= f.input(
 		:start_time,
@@ -46,7 +47,6 @@
 	<% @reservation.reservation_details.each.with_index(1) do |detail, index| %>
 		<%= f.fields_for :reservation_details, detail, child_index: index do |detail_form| %>
 			<%= detail_form.hidden_field :id, value: detail.id %>
-			<%= detail_form.input :store_id, collection: Store.all, label: '予約店舗', required: true %>
 			<%= detail_form.input(
 				:menu_id,
 				collection: Menu.all,

--- a/src/db/migrate/20190119034234_create_reservations.rb
+++ b/src/db/migrate/20190119034234_create_reservations.rb
@@ -4,6 +4,7 @@ class CreateReservations < ActiveRecord::Migration[5.1]
       t.integer :children_count, default: 0, comment: '随伴するお子様の数'
       t.text :reservation_comment
       
+      t.references :store, foreign_key: { on_delete: :cascade }
       t.references :staff, foreign_key: { on_delete: :cascade }, comment: '対応予定のスタッフid。キャンセル時にシフトとのリレーションを消すため、追加'
       t.references :customer, foreign_key: { on_delete: :cascade } 
       t.references :pregnant_state, null: true, default: nil, foreign_key: true

--- a/src/db/migrate/20190414154725_create_reservation_details.rb
+++ b/src/db/migrate/20190414154725_create_reservation_details.rb
@@ -3,7 +3,6 @@ class CreateReservationDetails < ActiveRecord::Migration[5.1]
     create_table :reservation_details, comment: '予約の詳細。シフトやメニューなどに紐づく' do |t|
       t.references :reservation, foreign_key: { on_delete: :cascade }
       t.references :menu, foreign_key: { on_delete: :nullify }
-      t.references :store, foreign_key: { on_delete: :cascade }
       t.integer :mimitsubo_count, comment: '耳つぼジュエリの個数。'
       t.timestamps
     end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -177,13 +177,11 @@ ActiveRecord::Schema.define(version: 2019_05_28_102117) do
   create_table "reservation_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "予約の詳細。シフトやメニューなどに紐づく", force: :cascade do |t|
     t.bigint "reservation_id"
     t.bigint "menu_id"
-    t.bigint "store_id"
     t.integer "mimitsubo_count", comment: "耳つぼジュエリの個数。"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["menu_id"], name: "index_reservation_details_on_menu_id"
     t.index ["reservation_id"], name: "index_reservation_details_on_reservation_id"
-    t.index ["store_id"], name: "index_reservation_details_on_store_id"
   end
 
   create_table "reservation_shifts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -198,6 +196,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_102117) do
   create_table "reservations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "children_count", default: 0, comment: "随伴するお子様の数"
     t.text "reservation_comment"
+    t.bigint "store_id"
     t.bigint "staff_id", comment: "対応予定のスタッフid。キャンセル時にシフトとのリレーションを消すため、追加"
     t.bigint "customer_id"
     t.bigint "pregnant_state_id"
@@ -212,6 +211,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_102117) do
     t.index ["customer_id"], name: "index_reservations_on_customer_id"
     t.index ["pregnant_state_id"], name: "index_reservations_on_pregnant_state_id"
     t.index ["staff_id"], name: "index_reservations_on_staff_id"
+    t.index ["store_id"], name: "index_reservations_on_store_id"
   end
 
   create_table "roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -353,12 +353,12 @@ ActiveRecord::Schema.define(version: 2019_05_28_102117) do
   add_foreign_key "reservation_detail_options", "reservation_details", on_delete: :cascade
   add_foreign_key "reservation_details", "menus", on_delete: :nullify
   add_foreign_key "reservation_details", "reservations", on_delete: :cascade
-  add_foreign_key "reservation_details", "stores", on_delete: :cascade
   add_foreign_key "reservation_shifts", "reservations", on_delete: :cascade
   add_foreign_key "reservation_shifts", "shifts", on_delete: :cascade
   add_foreign_key "reservations", "customers", on_delete: :cascade
   add_foreign_key "reservations", "pregnant_states"
   add_foreign_key "reservations", "staffs", on_delete: :cascade
+  add_foreign_key "reservations", "stores", on_delete: :cascade
   add_foreign_key "shifts", "staffs", on_delete: :cascade
   add_foreign_key "shifts", "stores", on_delete: :cascade
   add_foreign_key "skill_staffs", "skills", on_delete: :cascade


### PR DESCRIPTION
# 対応内容概要
- 予約と店舗を一対一に修正
-  フロントから、バックからの双方から予約登録可能であることを確認