### PR TITLE
管理画面からもキャンセルメールを送信可能にする

### DIFF
--- a/src/.ebextensions/02-whenever-crontab.config
+++ b/src/.ebextensions/02-whenever-crontab.config
@@ -15,6 +15,6 @@ files:
       . $EB_SUPPORT_DIR/envvars
       . $EB_SCRIPT_DIR/use-app-ruby.sh
 
-      cd $EB_DEPLOY_DIR
+      cd /var/app/current/src
       su -c "bundle exec whenever --update-cron"
       su -c "crontab -l"

--- a/src/.ebextensions/02-whenever-crontab.config
+++ b/src/.ebextensions/02-whenever-crontab.config
@@ -15,6 +15,6 @@ files:
       . $EB_SUPPORT_DIR/envvars
       . $EB_SCRIPT_DIR/use-app-ruby.sh
 
-      cd /var/app/current/src
+      cd $EB_DEPLOY_DIR
       su -c "bundle exec whenever --update-cron"
       su -c "crontab -l"

--- a/src/app/controllers/reservations_controller.rb
+++ b/src/app/controllers/reservations_controller.rb
@@ -90,7 +90,13 @@ class ReservationsController < ApplicationController
   # DELETE /reservations/1
   # DELETE /reservations/1.json
   def destroy
-    Reservation.find(params[:id]).cancel
+    reservation = Reservation.find(params[:id])
+    reservation.cancel
+
+    unless params[:do_send_cancel_mail?].nil?
+      ReservationMailer.cancel_reservation(reservation).deliver_now
+    end
+
     respond_to do |format|
       format.html { redirect_to reservations_url, notice: '予約をキャンセルいたしました。' }
       format.json { head :no_content }

--- a/src/app/views/reservations/show.html.erb
+++ b/src/app/views/reservations/show.html.erb
@@ -1,16 +1,19 @@
 <h1>予約詳細</h1>
 <%= render "form" %>
 
+<br>
+
 <% unless @reservation.canceled? %>
-  <div class="mt-4">
-    <%= link_to(
-      reservation_path(@reservation.id),
+  <%=
+    simple_form_for(
+      @reservation,
       method: :delete,
-      data: { confirm: '本当にキャンセルしますか？' }
-    ) do %>
-      <button type="button" class="btn btn-outline-primary">
-        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>キャンセル
-      </button>
-    <% end %>
-  </div>
+      data: { confirm: "本当にキャンセルしますか？\nまた、キャンセルメールを送信有無を再度ご確認ください。" },
+      class: 'mt-4'
+    ) do |form| 
+  %>
+    <%= form.button :submit, value: 'キャンセル', class: 'btn btn-outline-primary' %>
+    <%= check_box_tag :do_send_cancel_mail?, true, checked: true %>
+    <%= label_tag 'キャンセルメールを送信する' %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
# 対応内容
- 管理画面からのキャンセル時にもメール送信を可能にする
- メールの送信可否を選択できるように修正
- メッセージの修正
- AWSの更新によるデプロイ失敗をなくす対応