### PR TITLE
FC権限に関する制御の追加

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -27,4 +27,10 @@ class ApplicationController < ActionController::Base
     store_ids = viewable_stores.pluck(:id)
     return Staff.where_store_id(store_ids).uniq
   end
+
+  # 管理者のみ管理者権限に変更できるようにする
+  def viewable_roles
+    return Role.all if current_staff.role.admin?
+    return Role.viewable?(view_context.current_store)
+  end
 end

--- a/src/app/controllers/staffs_controller.rb
+++ b/src/app/controllers/staffs_controller.rb
@@ -92,7 +92,7 @@ class StaffsController < ApplicationController
   protected
     def set_relation_models
       @stores = viewable_stores
-      @roles = Role.all
+      @roles = viewable_roles
       @skills = Skill.all
     end
 

--- a/src/app/models/role.rb
+++ b/src/app/models/role.rb
@@ -2,9 +2,15 @@ class Role < ApplicationRecord
   has_many :staffs
 
   ADMIN = 1
-  HEAD = 2
+  HEAD = 2 # 本部権限
   MANAGER = 3
   STAFF = 4
+
+  scope :viewable?, -> (store) {
+    roles = where.not(id: ADMIN)
+    roles = roles.where.not(id: HEAD) if store.franchised?
+    return roles
+  }
 
   def admin?
     return self.id === ADMIN

--- a/src/app/views/staffs/_form.html.erb
+++ b/src/app/views/staffs/_form.html.erb
@@ -18,7 +18,7 @@
         as: :check_boxes,
         wrapper: :horizontal_collection_inline,
         collection: @stores.map{|store| [store.name, store.id]},
-        # required: trueを使うと全チェックが必要になる 
+        # required: trueを使うと全チェックが必要になる
         label: '所属店舗<abbr>&nbsp;(必須)</abbr>'.html_safe,
         checked: @staff.stores.exists? ? @staff.stores.pluck(:id) : [],
         include_hidden: false,
@@ -40,9 +40,14 @@
         class: 'foobarbaz'
       ) %>
       <%= f.input :employment_type, as: :select, label: '雇用区分', collection: Settings.employment_type.map.with_index{|name, id| [name, id]}, default: @staff.employment_type%>
-      <% if request.path_info != new_staff_path || current_staff.role_id == 1%>
-        <%= f.input :role_id, as: :select, collection: @roles.map{|role| [role.name, role.id]}, label: 'システム利用権限', default: 0%>
-      <%end%>
+      <%= f.input(
+        :role_id,
+        as: :select,
+        collection: @roles.map{|role| [role.name, role.id]},
+        label: 'システム利用権限',
+        disabled: @staff.persisted? && !current_staff.role.manager?,
+        required: true
+      ) %>
       <%= f.input :login, label: "ログインID", required: true %>
 
       <% if @staff.id === current_staff.id || current_staff.role.manager? %>


### PR DESCRIPTION
FC権限に関する制御の追加
- 管理者のみ管理者権限に変更できるように修正
- fc店は本部権限に変更できないように修正
- スタッフ登録画面のリファクタリング