### PR TITLE
顧客が検索できなくなるバグ対応

### DIFF
--- a/src/app/controllers/concerns/reservation_searchable.rb
+++ b/src/app/controllers/concerns/reservation_searchable.rb
@@ -6,8 +6,8 @@ module Concerns::ReservationSearchable
     reservations = reservations.order_reserved_at if @order === 'reserved_at'
     reservations = reservations.order('id DESC')
 
-    reservations = reservations.like_customer_name(@customer_name)
-    reservations = reservations.like_customer_tel(@customer_tel)
+    reservations = reservations.like_customer_name(@customer_name) if @customer_name.present?
+    reservations = reservations.like_customer_tel(@customer_tel) if @customer_tel.present?
     
     reservations = reservations.where('reservation_date >= ?', @from_date) if @from_date.present?
     reservations = reservations.where('reservation_date <= ?', @to_date) if @to_date.present?

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -44,15 +44,15 @@ class Customer < ApplicationRecord
   }
 
   scope :like_name, ->(name){
-    where("concat(last_name, first_name) like ?", "%#{name}%")
+    where("concat(last_name, first_name) like ?", "%#{name}%") if name.present?
   }
 
   scope :like_tel, -> (tel) {
-    where('tel LIKE ?', "%#{tel}%")
+    where('tel LIKE ?', "%#{tel}%") if tel.present?
   }
 
   scope :like_email, -> (email) {
-    where('email LIKE ?', "%#{email}%")
+    where('email LIKE ?', "%#{email}%") if email.present?
   }
 
   attr_accessor :age


### PR DESCRIPTION
# 対応内容
- 検索値のパラメータを確認し、空の場合はクエリを発行しない処理を追加