### PR TITLE
一般スタッフでも顧客のパスワードを変更できるようにする

### DIFF
--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -117,12 +117,10 @@
       <% if @customer.provider === 'email' %>
         <%= f.input :uid, label: 'ログインID', hint: '会員の場合、メールアドレスを元に補完されます。', readonly: true %>
       <% end %>
-      <% if current_staff.role.manager? %>
-        <%= f.input :password,
-          label: 'パスワード',
-          hint: 'パスワードは英字/数字を含む8文字以上にしてください'
-        %>
-      <% end %>
+      <%= f.input :password,
+        label: 'パスワード',
+        hint: 'パスワードは英字/数字を含む8文字以上にしてください'
+      %>
       <%= f.button :submit, class: 'btn btn-primary' %>
       <%= link_to '戻る', customers_path, class: 'btn btn-light' %>
     </div>


### PR DESCRIPTION
## 概要
一般スタッフでも顧客のパスワードを変更できるようにする

## Trello
【BE】一般スタッフでも顧客のパスワードを変更できるようにする ( https://trello.com/c/fBBhNWTe )

## 備考
権限表（顧客周り） ( https://github.com/egg-system/olive-back/wiki/%E6%A8%A9%E9%99%90%E8%A1%A8%EF%BC%88%E9%A1%A7%E5%AE%A2%E5%91%A8%E3%82%8A%EF%BC%89 )