### PR TITLE
メールアドレスを一意にする

### DIFF
--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -97,7 +97,7 @@ class CustomersController < ApplicationController
     def customer_params
       params.require(:customer).permit(
         :fmid, :first_name, :last_name, :first_kana, :last_kana,
-        :tel, :fixed_line_tel, :email, :can_receive_mail,
+        :tel, :fixed_line_tel, :display_email, :can_receive_mail,
         :first_visit_store_id, :first_visited_at, :last_visit_store_id, :comment,
         :zip_code, :address, :birthday, :card_number, :has_registration_card,
         :introducer, :children_count, :baby_age_id,

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -33,7 +33,7 @@ class Customer < ApplicationRecord
 
   validates :tel, numericality: { allow_blank: true }
   validates :password, presence: true, on: :create, if: :member?
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true
 
   #left join
   scope :join_size, ->{

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -33,6 +33,7 @@ class Customer < ApplicationRecord
 
   validates :tel, numericality: { allow_blank: true }
   validates :password, presence: true, on: :create, if: :member?
+  validates :email, presence: true
 
   #left join
   scope :join_size, ->{

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -33,9 +33,7 @@ class Customer < ApplicationRecord
 
   validates :tel, numericality: { allow_blank: true }
   validates :password, presence: true, on: :create, if: :member?
-  validates :email, uniqueness: true, unless: :common_email?
-  
-  before_save :filter_email
+  validates :email, uniqueness: true
 
   #left join
   scope :join_size, ->{
@@ -58,7 +56,7 @@ class Customer < ApplicationRecord
     where('email LIKE ?', "%#{email}%") if email.present?
   }
 
-  attr_accessor :age
+  attr_accessor :age, :display_email
 
   def age
     return nil if self.birthday.nil?
@@ -67,6 +65,15 @@ class Customer < ApplicationRecord
 
   def full_name
     return self.last_name + ' ' + self.first_name
+  end
+
+  def display_email
+    return nil if self.new_record?
+    return self.email.nil? ? self.common_email : self.email
+  end
+
+  def display_email=(email)
+    self.email = email unless email === self.common_email
   end
 
   protected
@@ -80,14 +87,10 @@ class Customer < ApplicationRecord
   end
 
   def sync_none_uid
-    self.uid = Time.now.to_s if is_none_provider?
+    self.uid = Time.now.to_s unless is_none_provider?
   end
 
-  def common_email?
-    self.email === Settings.customer.common_email
-  end
-
-  def filter_email
-    self.email = nil if common_email?
+  def common_email
+    return Settings.customer.common_email
   end
 end

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -13,6 +13,7 @@ class Customer < ApplicationRecord
     class_name: 'Store',
     foreign_key: 'first_visit_store_id'
   )
+
   belongs_to(
     :last_visit_store,
     optional: true,
@@ -33,7 +34,7 @@ class Customer < ApplicationRecord
 
   validates :tel, numericality: { allow_blank: true }
   validates :password, presence: true, on: :create, if: :member?
-  validates :email, uniqueness: true
+  validates :email, uniqueness: true, unless: :common_email?
 
   #left join
   scope :join_size, ->{
@@ -94,6 +95,10 @@ class Customer < ApplicationRecord
 
   def display_email=(email)
     self.email = email unless email === self.common_email
+  end
+
+  def common_email?
+    return self.display_email === self.common_email
   end
 
   protected

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -18,7 +18,8 @@
         :email,
         label: 'メールアドレス',
         readonly: @customer.persisted? && !current_staff.role.admin?,
-        hint: current_staff.role.admin? ? '' : 'システム管理者のみ変更可能です'
+        hint: current_staff.role.admin? ? '' : 'システム管理者のみ変更可能です',
+        required: true
       ) %>
       <%= f.input(
         :can_receive_mail,

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -15,12 +15,13 @@
       <%= f.input :tel, label: '電話番号', required: @customer.new_record? %>
       <%= f.input :fixed_line_tel, label: '固定電話番号' %>
       <%= f.input(
-        :email,
+        :display_email,
         label: 'メールアドレス',
         readonly: @customer.persisted? && !current_staff.role.admin?,
-        hint: current_staff.role.admin? ? "不要な場合は #{Settings.customer.common_email} を入力してください" : 'システム管理者のみ変更可能です',
-        required: true,
-        input_html: @customer.persisted? && @customer.email.nil? ? { value: Settings.customer.common_email } : {}
+        hint: current_staff.role.admin? ? 
+          "不明な場合は #{Settings.customer.common_email} を入力してください"
+          : 'システム管理者のみ変更可能です',
+        required: true
       ) %>
       <%= f.input(
         :can_receive_mail,
@@ -113,7 +114,10 @@
         :provider,
         label: '会員/非会員',
         as: :select,
-        hint: '会員にする場合、メールアドレスとパスワードの入力が必須になります',
+        hint: "
+          会員にする場合、パスワードの入力が必須になります。
+          ※ メールアドレスが#{Settings.customer.common_email}の方は会員にできません。
+        ",
         collection: { '非会員' => :none, '会員' => :email }
       ) %>
       <% if @customer.provider === 'email' %>

--- a/src/db/migrate/20191214132436_change_customers_columns.rb
+++ b/src/db/migrate/20191214132436_change_customers_columns.rb
@@ -1,0 +1,9 @@
+class ChangeCustomersColumns < ActiveRecord::Migration[5.2]
+  def change
+    change_column :customers, :email, :string, default: "test@test.com"
+
+    Customer.all.each { |customer|
+      customer.update_attributes(email: "test@test.com") if !customer.email.present?
+    }
+  end
+end

--- a/src/db/migrate/20191214132436_change_customers_columns.rb
+++ b/src/db/migrate/20191214132436_change_customers_columns.rb
@@ -1,9 +1,9 @@
 class ChangeCustomersColumns < ActiveRecord::Migration[5.2]
   def change
-    change_column :customers, :email, :string, default: "test@test.com"
+    change_column :customers, :email, :string, default: "common.mail@olivebodycare.healthcare"
 
     Customer.all.each { |customer|
-      customer.update_attributes(email: "test@test.com") if !customer.email.present?
+      customer.update_attributes(email: "common.mail@olivebodycare.healthcare") if !customer.email.present?
     }
   end
 end

--- a/src/db/migrate/20191214132436_change_customers_columns.rb
+++ b/src/db/migrate/20191214132436_change_customers_columns.rb
@@ -1,9 +1,9 @@
 class ChangeCustomersColumns < ActiveRecord::Migration[5.2]
   def change
-    change_column :customers, :email, :string, default: "common.mail@olivebodycare.healthcare"
+    change_column :customers, :email, :string, null: false
 
-    Customer.all.each { |customer|
-      customer.update_attributes(email: "common.mail@olivebodycare.healthcare") if !customer.email.present?
+    Customer.where(email: [nil, '']).each { |customer|
+      customer.update_attributes(email: "common.mail@olivebodycare.healthcare")
     }
   end
 end

--- a/src/db/migrate/20191221111160_change_customers_columns.rb
+++ b/src/db/migrate/20191221111160_change_customers_columns.rb
@@ -3,7 +3,8 @@ class ChangeCustomersColumns < ActiveRecord::Migration[5.2]
     change_column :customers, :email, :string, null: true, default: nil
 
     Customer.where(email: ['', Settings.customer.common_email]).each { |customer|
-      customer.update!(email: nil)
+      customer.email = nil
+      customer.save!(validate: false)
     }
   end
 end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2019_12_14_132436) do
     t.bigint "size_id", comment: "サイズ"
     t.bigint "visit_reason_id", comment: "来店経緯"
     t.bigint "nearest_station_id", comment: "最寄り駅"
-    t.string "email", default: "test@test.com", null: false
+    t.string "email", default: "common.mail@olivebodycare.healthcare", null: false
     t.string "encrypted_password", comment: "非会員の場合、nullにする"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2019_12_14_132436) do
     t.bigint "size_id", comment: "サイズ"
     t.bigint "visit_reason_id", comment: "来店経緯"
     t.bigint "nearest_station_id", comment: "最寄り駅"
-    t.string "email", default: "common.mail@olivebodycare.healthcare", null: false
+    t.string "email", null: false
     t.string "encrypted_password", comment: "非会員の場合、nullにする"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_09_104415) do
+ActiveRecord::Schema.define(version: 2019_12_14_132436) do
 
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2019_11_09_104415) do
     t.bigint "size_id", comment: "サイズ"
     t.bigint "visit_reason_id", comment: "来店経緯"
     t.bigint "nearest_station_id", comment: "最寄り駅"
-    t.string "email", default: "", null: false
+    t.string "email", default: "test@test.com", null: false
     t.string "encrypted_password", comment: "非会員の場合、nullにする"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"


### PR DESCRIPTION
## 概要
* フォームでメールアドレスを必須&空文字不可に
* DBの`email`のデフォルト値を修正し、空文字が入力されている場合に`test@test.com`を入れるmigrationファイルを作成

## trello
https://trello.com/c/U21awW1V