### PR TITLE
登録エラー時のメッセージを変更する

### DIFF
--- a/src/app/views/application/_form_error.erb
+++ b/src/app/views/application/_form_error.erb
@@ -1,0 +1,8 @@
+<% if errors.any? %>
+  <div class="alert alert-danger">
+    <h4 class="alert-heading"><%= I18n.t('simple_form.error_notification.default_message') %></h4>
+    <% errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
+<% end %>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -1,13 +1,6 @@
 <div class="form-wrapper">
   <%= simple_form_for(@customer, wrapper: :horizontal_form, html: { class: 'form-horizontal', autocomplete: 'off' }) do |f|%>
-    <% if @customer.errors.any? %>
-      <div class="alert alert-danger">
-        <h4 class="alert-heading"><%= I18n.t('simple_form.error_notification.default_message') %></h4>
-        <% @customer.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </div>
-    <% end %>
+    <%= render 'application/form_error', errors: @customer.errors %>
 
     <div class="form-center">
       <% if @customer.persisted? %>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -1,13 +1,14 @@
 <div class="form-wrapper">
   <%= simple_form_for(@customer, wrapper: :horizontal_form, html: { class: 'form-horizontal', autocomplete: 'off' }) do |f|%>
-    <%= f.error_notification %>
-    <% if f.object.errors.messages.present? %>
-      <% f.object.errors.messages.each do |attr, msgs| %>
-        <%= f.error_notification message: f.object.errors.full_messages_for(attr).first %>
-      <% end %>
-    <% elsif f.object.errors[:base].present? %>
-      <%= f.error_notification message: f.object.errors[:base].to_sentence %>
+    <% if @customer.errors.any? %>
+      <div class="alert alert-danger">
+        <h4 class="alert-heading"><%= I18n.t('simple_form.error_notification.default_message') %></h4>
+        <% @customer.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </div>
     <% end %>
+
     <div class="form-center">
       <% if @customer.persisted? %>
         <%= f.input :id, label: '顧客ID', readonly: true %>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -1,7 +1,13 @@
 <div class="form-wrapper">
   <%= simple_form_for(@customer, wrapper: :horizontal_form, html: { class: 'form-horizontal', autocomplete: 'off' }) do |f|%>
     <%= f.error_notification %>
-    <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+    <% if f.object.errors.messages.present? %>
+      <% f.object.errors.messages.each do |attr, msgs| %>
+        <%= f.error_notification message: f.object.errors.full_messages_for(attr).first %>
+      <% end %>
+    <% elsif f.object.errors[:base].present? %>
+      <%= f.error_notification message: f.object.errors[:base].to_sentence %>
+    <% end %>
     <div class="form-center">
       <% if @customer.persisted? %>
         <%= f.input :id, label: '顧客ID', readonly: true %>


### PR DESCRIPTION
## 概要
customerの登録・更新でエラーになった際にエラー詳細を表示するよう修正
![スクリーンショット 2020-01-19 17 57 15](https://user-images.githubusercontent.com/55093787/72678179-d3e34f00-3ae6-11ea-9fc9-85a1507dfbe1.png)

## Trello
【BE】登録エラー時のメッセージを変更する ( https://trello.com/c/JT3C0YjW )

## 備考
```
f.object.errors[:base].to_sentence
```
でエラーが表示されるパターンがイマイチ分からず`elsif`での実装にしています