### PR TITLE
顧客テーブルに、削除フラグの追加

### DIFF
--- a/src/app/assets/stylesheets/customers.scss
+++ b/src/app/assets/stylesheets/customers.scss
@@ -22,9 +22,6 @@ abbr {
       td {
         width: 80%;
       }
-      .radio_button {
-        margin-right: 0.75rem;
-      }
     }
 
     .button-section {

--- a/src/app/assets/stylesheets/customers.scss
+++ b/src/app/assets/stylesheets/customers.scss
@@ -22,6 +22,9 @@ abbr {
       td {
         width: 80%;
       }
+      .radio_button {
+        margin-right: 0.75rem;
+      }
     }
 
     .button-section {

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -13,7 +13,7 @@ class CustomersController < ApplicationController
     @customers = @customers.like_name(@search_params[:name])
     @customers = @customers.like_tel(@search_params[:tel])
     @customers = @customers.like_email(@search_params[:email])
-    @customers = @customers.deleted(@search_params[:is_deleted])
+    @customers = @customers.deleted(0) if @search_params[:include_deleted] != '1'
 
     @customers = @customers.paginate(@search_params[:page], 20)
   end
@@ -107,6 +107,6 @@ class CustomersController < ApplicationController
     end
 
     def search_params
-      params.permit(:name, :tel, :email, :is_deleted, :page)
+      params.permit(:name, :tel, :email, :include_deleted, :page)
     end
 end

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -13,6 +13,7 @@ class CustomersController < ApplicationController
     @customers = @customers.like_name(@search_params[:name])
     @customers = @customers.like_tel(@search_params[:tel])
     @customers = @customers.like_email(@search_params[:email])
+    @customers = @customers.deleted(@search_params[:is_deleted])
 
     @customers = @customers.paginate(@search_params[:page], 20)
   end
@@ -106,6 +107,6 @@ class CustomersController < ApplicationController
     end
 
     def search_params
-      params.permit(:name, :tel, :email, :page)
+      params.permit(:name, :tel, :email, :is_deleted, :page)
     end
 end

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -13,7 +13,10 @@ class CustomersController < ApplicationController
     @customers = @customers.like_name(@search_params[:name])
     @customers = @customers.like_tel(@search_params[:tel])
     @customers = @customers.like_email(@search_params[:email])
-    @customers = @customers.deleted(0) if @search_params[:include_deleted] != '1'
+
+    # 基本的に、未使用フラグの立った顧客は検索に表示しない
+    ## include_deletedがtrueの場合のみ、未使用フラグの立った顧客を検索結果に含める
+    @customers = @customers.where_deleted(false) unless @search_params[:include_deleted] === '1'
 
     @customers = @customers.paginate(@search_params[:page], 20)
   end
@@ -102,7 +105,7 @@ class CustomersController < ApplicationController
         :first_visit_store_id, :first_visited_at, :last_visit_store_id, :comment,
         :zip_code, :address, :birthday, :card_number, :has_registration_card,
         :introducer, :children_count, :baby_age_id,
-        :occupation_id, :zoomancy_id, :size_id, :provider, :password,          
+        :occupation_id, :zoomancy_id, :size_id, :provider, :password, :is_deleted        
       )
     end
 

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -57,7 +57,7 @@ class Customer < ApplicationRecord
   }
 
   scope :deleted, -> (is_deleted) {
-    where(is_deleted: is_deleted)
+    where(is_deleted: is_deleted) if is_deleted.present?
   }
 
   attr_accessor :age, :display_email

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -56,8 +56,8 @@ class Customer < ApplicationRecord
     where('email LIKE ?', "%#{email}%") if email.present?
   }
 
-  scope :deleted, -> (is_deleted) {
-    where(is_deleted: is_deleted) if is_deleted.present?
+  scope :where_deleted, -> (is_deleted) {
+    where(is_deleted: is_deleted)
   }
 
   attr_accessor :age, :display_email

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -56,6 +56,10 @@ class Customer < ApplicationRecord
     where('email LIKE ?', "%#{email}%") if email.present?
   }
 
+  scope :deleted, -> (is_deleted) {
+    where(is_deleted: is_deleted)
+  }
+
   attr_accessor :age, :display_email
 
   # 本メソッドは、メールアドレスの重複を前提としている

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -141,6 +141,19 @@
         default: @customer.size_id,
         include_blank: true
       ) %>
+      <div class="custom_row row">
+        <div class="custom_left col-sm-3">
+          <label></label>
+        </div>
+        <div class="custom_right col-sm-9">
+          <%= f.input(
+            :is_deleted?,
+            label: '削除済み',
+            as: :boolean,
+            disabled: true,
+          ) %>
+        </div>
+      </div>
       <%= f.button :submit, class: 'btn btn-primary' %>
       <%= link_to '戻る', customers_path, class: 'btn btn-light' %>
     </div>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -147,8 +147,7 @@
         wrapper: :horizontal_collection_inline,
         collection: { "未使用" => true, "使用中" => false },
         label: '使用状況',
-        checked: @customer.is_deleted,
-        disabled: true
+        checked: @customer.is_deleted
       ) %>
       <%= f.button :submit, class: 'btn btn-primary' %>
       <%= link_to '戻る', customers_path, class: 'btn btn-light' %>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -141,19 +141,15 @@
         default: @customer.size_id,
         include_blank: true
       ) %>
-      <div class="custom_row row">
-        <div class="custom_left col-sm-3">
-          <label></label>
-        </div>
-        <div class="custom_right col-sm-9">
-          <%= f.input(
-            :is_deleted?,
-            label: '未使用',
-            as: :boolean,
-            disabled: true,
-          ) %>
-        </div>
-      </div>
+      <%= f.input(
+        :is_deleted,
+        as: :radio_buttons,
+        wrapper: :horizontal_collection_inline,
+        collection: { "未使用" => true, "使用中" => false },
+        label: '使用状況',
+        checked: @customer.is_deleted,
+        disabled: true
+      ) %>
       <%= f.button :submit, class: 'btn btn-primary' %>
       <%= link_to '戻る', customers_path, class: 'btn btn-light' %>
     </div>

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -148,7 +148,7 @@
         <div class="custom_right col-sm-9">
           <%= f.input(
             :is_deleted?,
-            label: '削除済み',
+            label: '未使用',
             as: :boolean,
             disabled: true,
           ) %>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -26,7 +26,7 @@
             <td>
           </tr>
           <tr>
-            <th>削除済み</th>
+            <th>未使用</th>
             <td>
               <%= f.check_box :is_deleted, { class: "form-control", value: @search_params["is_deleted"] } %>
             <td>
@@ -63,7 +63,7 @@
             <th scope="col">サイズ</th>
             <th scope="col">診察券</th>
             <th scope="col">初回ご来店日</th>
-            <th scope="col">削除状況</th>
+            <th scope="col">使用状況</th>
             <th scope="col"></th>
           </tr>
         </thead>
@@ -80,7 +80,7 @@
               <td><%= customer.size_name %></td>
               <td><%= customer.has_registration_card == true ? '有' : '無' %></td>
               <td><%= customer.first_visited_at %></td>
-              <td><%= customer.is_deleted == true ? '削除済' : '未削除'%></td>
+              <td><%= customer.is_deleted == true ? '未使用' : '使用中'%></td>
               <td>
                 <ul>
                   <li><%= link_to '詳細へ', customer_path(customer.id) %></li>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -26,10 +26,9 @@
             <td>
           </tr>
           <tr>
-            <th>使用状況</th>
+            <th></th>
             <td>
-              <%= f.radio_button :is_deleted, 1, checked: @search_params["is_deleted"] == "1" %> <%= f.label :is_deleted, "未使用", { class: "radio_button", value: 1 } %>
-              <%= f.radio_button :is_deleted, 0, checked: @search_params["is_deleted"] == "0" %> <%= f.label :is_deleted, "使用中", { class: "radio_button", value: 0 } %>
+              <%= f.check_box :include_deleted, { checked: @search_params["include_deleted"] == '1' } %> <%= f.label :include_deleted, "未使用の顧客を含めて検索する" %>
             <td>
           </tr>
         </tbody>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -28,7 +28,10 @@
           <tr>
             <th></th>
             <td>
-              <%= f.check_box :include_deleted, { checked: @search_params["include_deleted"] == '1' } %> <%= f.label :include_deleted, "未使用の顧客を含めて検索する" %>
+              <%= f.check_box :include_deleted, {
+                checked: @search_params["include_deleted"] == '1'
+              } %>
+              <%= f.label :include_deleted, "未使用の顧客を含めて検索する" %>
             <td>
           </tr>
         </tbody>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -58,6 +58,7 @@
             <th scope="col">診察券</th>
             <th scope="col">初回ご来店日</th>
             <th scope="col">会員/非会員</th>
+            <th scope="col">削除状況</th>
             <th scope="col"></th>
           </tr>
         </thead>
@@ -75,6 +76,7 @@
               <td><%= customer.has_registration_card == true ? '有' : '無' %></td>
               <td><%= customer.first_visited_at %></td>
               <td><%= customer.provider == 'none' ? '非会員' : '会員'%></td>
+              <td><%= customer.is_deleted == true ? '削除済' : '未削除'%></td>
               <td>
                 <ul>
                   <li><%= link_to '詳細へ', customer_path(customer.id) %></li>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -25,6 +25,12 @@
               <%= f.text_field :email, { class: "form-control", value: @search_params["email"] } %>
             <td>
           </tr>
+          <tr>
+            <th>削除済み</th>
+            <td>
+              <%= f.check_box :is_deleted, { class: "form-control", value: @search_params["is_deleted"] } %>
+            <td>
+          </tr>
         </tbody>
       </table>
       <%end%>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -26,9 +26,10 @@
             <td>
           </tr>
           <tr>
-            <th>未使用</th>
+            <th>使用状況</th>
             <td>
-              <%= f.check_box :is_deleted, { class: "form-control", value: @search_params["is_deleted"] } %>
+              <%= f.radio_button :is_deleted, 1, checked: @search_params["is_deleted"] == "1" %> <%= f.label :is_deleted, "未使用", { class: "radio_button", value: 1 } %>
+              <%= f.radio_button :is_deleted, 0, checked: @search_params["is_deleted"] == "0" %> <%= f.label :is_deleted, "使用中", { class: "radio_button", value: 0 } %>
             <td>
           </tr>
         </tbody>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -63,7 +63,6 @@
             <th scope="col">サイズ</th>
             <th scope="col">診察券</th>
             <th scope="col">初回ご来店日</th>
-            <th scope="col">会員/非会員</th>
             <th scope="col">削除状況</th>
             <th scope="col"></th>
           </tr>
@@ -81,7 +80,6 @@
               <td><%= customer.size_name %></td>
               <td><%= customer.has_registration_card == true ? '有' : '無' %></td>
               <td><%= customer.first_visited_at %></td>
-              <td><%= customer.provider == 'none' ? '非会員' : '会員'%></td>
               <td><%= customer.is_deleted == true ? '削除済' : '未削除'%></td>
               <td>
                 <ul>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -36,7 +36,7 @@
             <th></th>
             <td>
               <%= f.check_box :include_deleted, {
-                checked: @search_params["include_deleted"] == '1'
+                checked: @search_params["include_deleted"] === '1'
               } %>
               <%= f.label :include_deleted, "未使用の顧客を含めて検索する" %>
             <td>

--- a/src/db/migrate/20200128144418_add_is_deleted_to_customers.rb
+++ b/src/db/migrate/20200128144418_add_is_deleted_to_customers.rb
@@ -1,0 +1,9 @@
+class AddIsDeletedToCustomers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :customers, :is_deleted, :boolean, default: false, comment: '削除フラグ'
+  end
+
+  def down
+    remove_column :customers, :is_deleted, :boolean
+  end
+end

--- a/src/db/migrate/20200128144418_add_is_deleted_to_customers.rb
+++ b/src/db/migrate/20200128144418_add_is_deleted_to_customers.rb
@@ -1,6 +1,16 @@
 class AddIsDeletedToCustomers < ActiveRecord::Migration[5.2]
   def up
-    add_column :customers, :is_deleted, :boolean, default: false, comment: '削除フラグ'
+    add_column(
+      :customers,
+      :is_deleted,
+      :boolean,
+      default: false,
+      comment: '
+        使用していない顧客に対し、trueにする。
+        いわゆる論理削除とは異なり、ユーザー側で値を変更する。
+        バグなどの原因になりうるため、システム側で特殊な処理は実施しない。
+      '
+    )
   end
 
   def down

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_21_111160) do
+ActiveRecord::Schema.define(version: 2020_01_28_144418) do
 
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2019_12_21_111160) do
     t.text "tokens"
     t.boolean "allow_password_change", default: false, comment: "パスワード変更に必要"
     t.integer "fmid"
+    t.boolean "is_deleted", default: false, comment: "削除フラグ"
     t.index ["baby_age_id"], name: "index_customers_on_baby_age_id"
     t.index ["email"], name: "index_customers_on_email"
     t.index ["first_visit_store_id"], name: "index_customers_on_first_visit_store_id"

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_144418) do
     t.text "tokens"
     t.boolean "allow_password_change", default: false, comment: "パスワード変更に必要"
     t.integer "fmid"
-    t.boolean "is_deleted", default: false, comment: "削除フラグ"
+    t.boolean "is_deleted", default: false, comment: "\n        使用していない顧客に対し、trueにする。\n        いわゆる論理削除とは異なり、ユーザー側で値を変更する。\n        バグなどの原因になりうるため、システム側で特殊な処理は実施しない。\n      "
     t.index ["baby_age_id"], name: "index_customers_on_baby_age_id"
     t.index ["email"], name: "index_customers_on_email"
     t.index ["first_visit_store_id"], name: "index_customers_on_first_visit_store_id"


### PR DESCRIPTION
## 概要
* 削除フラグ（`is_deleted`）の実装
* 顧客の一覧、詳細画面にreadonlyで表示
* 一覧で検索条件に追加

## Trello
顧客テーブルに、削除フラグの追加 ( https://trello.com/c/DYlPcHR7 )