### PR TITLE
重複アラート機能の追加実装

### DIFF
--- a/src/app/controllers/customers/duplicate_controller.rb
+++ b/src/app/controllers/customers/duplicate_controller.rb
@@ -33,6 +33,6 @@ class Customers::DuplicateController < ApplicationController
     end
 
     def group_duplicated_columns(search_params)
-      return search_params[:columns].present? ? search_params[:columns].split(',').map(&:to_s) : Settings.duplicated_customer.kana_tel.columns.map(&:to_s)
+      search_params[:columns].split(',').map(&:to_s)
     end
 end

--- a/src/app/controllers/customers/duplicate_controller.rb
+++ b/src/app/controllers/customers/duplicate_controller.rb
@@ -1,8 +1,11 @@
 class Customers::DuplicateController < ApplicationController
   def index
+    return if search_params[:columns].nil?
+
     # 重複1件につき、4倍の高さのため、件数は1/4にする ※ 顧客一覧は20件ずつで表示
     ## ペジネーション周りの情報を保持するため、変数名をpageにする
-    @duplicated_customer_page = Customer.group_duplicated(group_duplicated_columns(search_params))
+    @duplicated_customer_page = Customer
+      .group_duplicated(search_params[:columns])
       .select('group_concat(id) as duplicated_ids')
       .paginate(search_params[:page], 5)
 
@@ -29,10 +32,6 @@ class Customers::DuplicateController < ApplicationController
 
   private
     def search_params
-      params.permit(:page, :columns)
-    end
-
-    def group_duplicated_columns(search_params)
-      search_params[:columns].split(',').map(&:to_s)
+      params.permit(:page, columns: [])
     end
 end

--- a/src/app/controllers/customers/duplicate_controller.rb
+++ b/src/app/controllers/customers/duplicate_controller.rb
@@ -1,12 +1,8 @@
 class Customers::DuplicateController < ApplicationController
   def index
-    # 重複条件を抽出（表示用にも成形）
-    columns_info = create_columns_info(search_params)
-    @view_info = columns_info[:view_info]
-
     # 重複1件につき、4倍の高さのため、件数は1/4にする ※ 顧客一覧は20件ずつで表示
     ## ペジネーション周りの情報を保持するため、変数名をpageにする
-    @duplicated_customer_page = Customer.group_duplicated(columns_info[:columns])
+    @duplicated_customer_page = Customer.group_duplicated(create_group_duplicated_columns(search_params))
       .select('group_concat(id) as duplicated_ids')
       .paginate(search_params[:page], 5)
 
@@ -34,17 +30,8 @@ class Customers::DuplicateController < ApplicationController
       params.permit(:page, :columns)
     end
 
-    def create_columns_info(search_params)
-      columns_arr = search_params[:columns].present? ? search_params[:columns].split(',') : ['kana', 'tel']
-      result = { columns: [], view_info: [] }
-      if columns_arr.include?('kana')
-        result[:columns] = result[:columns].concat([:first_kana, :last_kana])
-        result[:view_info].push({ name: 'カナ', key: :full_kana })
-      end
-      if columns_arr.include?('tel')
-        result[:columns].push(:tel)
-        result[:view_info].push({ name: '電話番号', key: :tel })
-      end
+    def create_group_duplicated_columns(search_params)
+      result = search_params[:columns].present? ? search_params[:columns].split(',').map(&:to_s) : Settings.duplicated_customer.kana_tel.columns.map(&:to_s)
       result
     end
 end

--- a/src/app/controllers/customers/duplicate_controller.rb
+++ b/src/app/controllers/customers/duplicate_controller.rb
@@ -1,8 +1,12 @@
 class Customers::DuplicateController < ApplicationController
   def index
+    # 重複条件を抽出（表示用にも成形）
+    columns_info = create_columns_info(search_params)
+    @view_info = columns_info[:view_info]
+
     # 重複1件につき、4倍の高さのため、件数は1/4にする ※ 顧客一覧は20件ずつで表示
     ## ペジネーション周りの情報を保持するため、変数名をpageにする
-    @duplicated_customer_page = Customer.group_duplicate
+    @duplicated_customer_page = Customer.group_duplicated(columns_info[:columns])
       .select('group_concat(id) as duplicated_ids')
       .paginate(search_params[:page], 5)
 
@@ -27,6 +31,20 @@ class Customers::DuplicateController < ApplicationController
 
   private
     def search_params
-      params.permit(:page)
+      params.permit(:page, :columns)
+    end
+
+    def create_columns_info(search_params)
+      columns_arr = search_params[:columns].present? ? search_params[:columns].split(',') : ['kana', 'tel']
+      result = { columns: [], view_info: [] }
+      if columns_arr.include?('kana')
+        result[:columns] = result[:columns].concat([:first_kana, :last_kana])
+        result[:view_info].push({ name: 'カナ', key: :full_kana })
+      end
+      if columns_arr.include?('tel')
+        result[:columns].push(:tel)
+        result[:view_info].push({ name: '電話番号', key: :tel })
+      end
+      result
     end
 end

--- a/src/app/controllers/customers/duplicate_controller.rb
+++ b/src/app/controllers/customers/duplicate_controller.rb
@@ -2,7 +2,7 @@ class Customers::DuplicateController < ApplicationController
   def index
     # 重複1件につき、4倍の高さのため、件数は1/4にする ※ 顧客一覧は20件ずつで表示
     ## ペジネーション周りの情報を保持するため、変数名をpageにする
-    @duplicated_customer_page = Customer.group_duplicated(create_group_duplicated_columns(search_params))
+    @duplicated_customer_page = Customer.group_duplicated(group_duplicated_columns(search_params))
       .select('group_concat(id) as duplicated_ids')
       .paginate(search_params[:page], 5)
 
@@ -23,6 +23,8 @@ class Customers::DuplicateController < ApplicationController
         duplicated_ids.split(',').include?(customer.id.to_s)
       }
     }
+
+    @search_param_columns = search_params[:columns]
   end
 
   private
@@ -30,8 +32,7 @@ class Customers::DuplicateController < ApplicationController
       params.permit(:page, :columns)
     end
 
-    def create_group_duplicated_columns(search_params)
-      result = search_params[:columns].present? ? search_params[:columns].split(',').map(&:to_s) : Settings.duplicated_customer.kana_tel.columns.map(&:to_s)
-      result
+    def group_duplicated_columns(search_params)
+      return search_params[:columns].present? ? search_params[:columns].split(',').map(&:to_s) : Settings.duplicated_customer.kana_tel.columns.map(&:to_s)
     end
 end

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -118,14 +118,10 @@ class CustomersController < ApplicationController
 
     def create_duplicated_alerts
       result = []
-      if Customer.group_duplicated([:first_kana, :last_kana]).exists?
-        result.push({ message: 'カナ', columns: 'kana' })
-      end
-      if Customer.group_duplicated([:tel]).exists?
-        result.push({ message: '電話番号', columns: 'tel' })
-      end
-      if Customer.group_duplicated([:first_kana, :last_kana, :tel]).exists?
-        result.push({ message: 'カナと電話番号', columns: 'kana,tel' })
+      Settings.duplicated_customer.to_h.values.each do |item|
+        if Customer.group_duplicated(item.columns.map(&:to_s)).exists?
+          result.push({ message: item.name, columns: item.columns.join(',') })
+        end
       end
       result
     end

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -20,7 +20,7 @@ class CustomersController < ApplicationController
 
     @customers = @customers.paginate(@search_params[:page], 20)
 
-    # kana, tel, kana&telで重複チェック
+    # 重複チェック
     @duplicated_alerts = create_duplicated_alerts
   end
 

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -19,9 +19,6 @@ class CustomersController < ApplicationController
     @customers = @customers.where_deleted(false) unless @search_params[:include_deleted] === '1'
 
     @customers = @customers.paginate(@search_params[:page], 20)
-
-    # 重複チェック
-    @duplicated_alerts = create_duplicated_alerts
   end
 
   def search
@@ -114,15 +111,5 @@ class CustomersController < ApplicationController
 
     def search_params
       params.permit(:name, :tel, :email, :include_deleted, :page)
-    end
-
-    def create_duplicated_alerts
-      result = []
-      Settings.duplicated_customer.to_h.values.each do |item|
-        if Customer.group_duplicated(item.columns.map(&:to_s)).exists?
-          result.push({ message: item.name, columns: item.columns.join(',') })
-        end
-      end
-      result
     end
 end

--- a/src/app/helpers/customers_helper.rb
+++ b/src/app/helpers/customers_helper.rb
@@ -1,0 +1,13 @@
+module CustomersHelper
+  # 重複ユーザーのグループから重複しているcolumnのkeyの配列を返す
+  def duplicated_customer_views(customers)
+    result = []
+    if customers.first.first_kana === customers.second.first_kana && customers.first.last_kana === customers.second.last_kana
+      result.push({ name: Settings.duplicated_customer.kana.name, value: customers.first.full_kana })
+    end
+    if customers.first.tel === customers.second.tel
+      result.push({ name: Settings.duplicated_customer.tel.name, value: customers.first.tel })
+    end
+    result
+  end
+end

--- a/src/app/helpers/customers_helper.rb
+++ b/src/app/helpers/customers_helper.rb
@@ -4,7 +4,7 @@ module CustomersHelper
       if Customer.group_duplicated(item.columns.map(&:to_s)).exists?
         { message: item.name, columns: item.columns.join(',') }
       end
-    end.select { |item| item.present? }
+    end.select(&:present?)
   end
 
   def duplicated_customer_views(columns, customers)

--- a/src/app/helpers/customers_helper.rb
+++ b/src/app/helpers/customers_helper.rb
@@ -1,12 +1,20 @@
 module CustomersHelper
-  def duplicated_customer_views(customers)
-    result = []
-    if customers.first.first_kana === customers.second.first_kana && customers.first.last_kana === customers.second.last_kana
-      result.push({ name: Settings.duplicated_customer.kana.name, value: customers.first.full_kana })
+  def duplicated_customer_alerts
+    return Settings.duplicated_customer.to_h.values.map do |item|
+      if Customer.group_duplicated(item.columns.map(&:to_s)).exists?
+        { message: item.name, columns: item.columns.join(',') }
+      end
+    end.select { |item| item.present? }
+  end
+
+  def duplicated_customer_views(columns, customers)
+    columns_str = columns.present? ? columns : ''
+    if columns_str === Settings.duplicated_customer.kana.columns.join(',')
+      return "カナの<span class='text-danger'>#{customers.first.full_kana}</span>が重複".html_safe
+    elsif columns_str === Settings.duplicated_customer.tel.columns.join(',')
+      return "電話番号の<span class='text-danger'>#{customers.first.tel}</span>が重複".html_safe
+    elsif columns_str === Settings.duplicated_customer.kana_tel.columns.join(',')
+      return "カナの<span class='text-danger'>#{customers.first.full_kana}</span>と、電話番号の<span class='text-danger'>#{customers.first.tel}</span>が重複".html_safe
     end
-    if customers.first.tel === customers.second.tel
-      result.push({ name: Settings.duplicated_customer.tel.name, value: customers.first.tel })
-    end
-    result
   end
 end

--- a/src/app/helpers/customers_helper.rb
+++ b/src/app/helpers/customers_helper.rb
@@ -1,20 +1,31 @@
 module CustomersHelper
   def duplicated_customer_alerts
-    return Settings.duplicated_customer.to_h.values.map do |item|
-      if Customer.group_duplicated(item.columns.map(&:to_s)).exists?
-        { message: item.name, columns: item.columns.join(',') }
+    return Settings.duplicated_customer.to_h.values.map { |item|
+      if Customer.group_duplicated(item.columns).exists?
+        { message: item.name, columns: item.columns }
       end
-    end.select(&:present?)
+    }.select(&:present?)
   end
 
-  def duplicated_customer_views(columns, customers)
-    columns_str = columns.present? ? columns : ''
-    if columns_str === Settings.duplicated_customer.kana.columns.join(',')
+  def duplicated_customer_views(customers)
+    # 重複していない場合、全てのfull_kana or telはバラバラになるため、count > 1になる
+    duplicated_kana = customers.map(&:full_kana).uniq.count === 1
+    duplicated_tel = customers.map(&:tel).uniq.count === 1
+
+    if duplicated_kana && duplicated_tel
+      return "カナの<span class='text-danger'>
+          #{customers.first.full_kana}
+        </span>と、電話番号の<span class='text-danger'>
+          #{customers.first.tel}
+        </span>が重複".html_safe
+    end
+
+    if duplicated_kana
       return "カナの<span class='text-danger'>#{customers.first.full_kana}</span>が重複".html_safe
-    elsif columns_str === Settings.duplicated_customer.tel.columns.join(',')
+    end
+
+    if duplicated_tel
       return "電話番号の<span class='text-danger'>#{customers.first.tel}</span>が重複".html_safe
-    elsif columns_str === Settings.duplicated_customer.kana_tel.columns.join(',')
-      return "カナの<span class='text-danger'>#{customers.first.full_kana}</span>と、電話番号の<span class='text-danger'>#{customers.first.tel}</span>が重複".html_safe
     end
   end
 end

--- a/src/app/helpers/customers_helper.rb
+++ b/src/app/helpers/customers_helper.rb
@@ -1,5 +1,4 @@
 module CustomersHelper
-  # 重複ユーザーのグループから重複しているcolumnのkeyの配列を返す
   def duplicated_customer_views(customers)
     result = []
     if customers.first.first_kana === customers.second.first_kana && customers.first.last_kana === customers.second.last_kana

--- a/src/app/helpers/customers_helper.rb
+++ b/src/app/helpers/customers_helper.rb
@@ -1,5 +1,0 @@
-module CustomersHelper
-  def duplicated_customer_exists?()
-    return Customer.group_duplicate.exists
-  end
-end

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -61,8 +61,8 @@ class Customer < ApplicationRecord
     where(is_deleted: is_deleted)
   }
 
-  scope :group_duplicate, -> {
-    group(:first_kana, :last_kana, :tel).having('count(*) >= 2')
+  scope :group_duplicated, -> (columns) {
+    group(columns).having('count(*) >= 2')
   }
 
   attr_accessor :age, :display_email

--- a/src/app/views/customers/duplicate/index.html.erb
+++ b/src/app/views/customers/duplicate/index.html.erb
@@ -13,12 +13,16 @@
     <% else %>
       <% @duplicated_customer_groups.each do |customer_group| %>
         <% customer = customer_group.first %>
-        カナの<span class="text-danger">
-          <%= customer.full_kana %>
-        </span>と、電話番号の
-        <span class="text-danger">
-          <%= customer.tel %>
-        </span>が重複
+        <% @view_info.each_with_index do |info, index| %>
+          <%= info[:name] %>の
+          <span class="text-danger">
+            <%= customer.send(info[:key]) %>
+          </span>
+          <% if index + 1 != @view_info.length %>
+            と、
+          <% end %>
+        <% end %>
+        が重複
         <%= render 'customers/table', { customers: customer_group } %>
       <% end %>
     <% end %>

--- a/src/app/views/customers/duplicate/index.html.erb
+++ b/src/app/views/customers/duplicate/index.html.erb
@@ -12,17 +12,8 @@
       <p>該当データがありません</p>
     <% else %>
       <% @duplicated_customer_groups.each do |customer_group| %>
-        <% duplicated_customer_views = duplicated_customer_views(customer_group) %>
-        <% duplicated_customer_views.each_with_index do |item, index| %>
-          <%= item[:name] %>の
-          <span class="text-danger">
-            <%= item[:value] %>
-          </span>
-          <% if index + 1 != duplicated_customer_views.length %>
-            と、
-          <% end %>
-        <% end %>
-        が重複
+        <%= duplicated_customer_views(@search_param_columns, customer_group) %>
+
         <%= render 'customers/table', { customers: customer_group } %>
       <% end %>
     <% end %>

--- a/src/app/views/customers/duplicate/index.html.erb
+++ b/src/app/views/customers/duplicate/index.html.erb
@@ -12,13 +12,13 @@
       <p>該当データがありません</p>
     <% else %>
       <% @duplicated_customer_groups.each do |customer_group| %>
-        <% customer = customer_group.first %>
-        <% @view_info.each_with_index do |info, index| %>
-          <%= info[:name] %>の
+        <% duplicated_customer_views = duplicated_customer_views(customer_group) %>
+        <% duplicated_customer_views.each_with_index do |item, index| %>
+          <%= item[:name] %>の
           <span class="text-danger">
-            <%= customer.send(info[:key]) %>
+            <%= item[:value] %>
           </span>
-          <% if index + 1 != @view_info.length %>
+          <% if index + 1 != duplicated_customer_views.length %>
             と、
           <% end %>
         <% end %>

--- a/src/app/views/customers/duplicate/index.html.erb
+++ b/src/app/views/customers/duplicate/index.html.erb
@@ -12,7 +12,7 @@
       <p>該当データがありません</p>
     <% else %>
       <% @duplicated_customer_groups.each do |customer_group| %>
-        <%= duplicated_customer_views(@search_param_columns, customer_group) %>
+        <%= duplicated_customer_views(customer_group) %>
 
         <%= render 'customers/table', { customers: customer_group } %>
       <% end %>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -2,9 +2,12 @@
 <div id="customer_index">
   <p class="common_title">顧客一覧</p>
 
-  <% if duplicated_customer_exists? %>
+  <% if @duplicated_alerts.present? %>
     <div class="alert alert-danger">
-      <%= link_to '重複しているユーザーが存在します', customers_duplicate_index_path %>
+      <h4 class="alert-heading">重複しているユーザーが存在します</h4>
+      <% @duplicated_alerts.each do |alert| %>
+        <li><%= link_to alert[:message], customers_duplicate_index_path(columns: alert[:columns]) %></li>
+      <% end %>
     </div>
   <% end %>
   

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -6,7 +6,10 @@
     <div class="alert alert-danger">
       <h4 class="alert-heading">重複しているユーザーが存在します</h4>
       <% duplicated_customer_alerts.each do |alert| %>
-        <li><%= link_to alert[:message], customers_duplicate_index_path(columns: alert[:columns]) %></li>
+        <li><%= link_to(
+          "「#{alert[:message]}」が重複している顧客を確認する",
+          customers_duplicate_index_path(columns: alert[:columns])
+        ) %></li>
       <% end %>
     </div>
   <% end %>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -2,10 +2,10 @@
 <div id="customer_index">
   <p class="common_title">顧客一覧</p>
 
-  <% if @duplicated_alerts.present? %>
+  <% if duplicated_customer_alerts.present? %>
     <div class="alert alert-danger">
       <h4 class="alert-heading">重複しているユーザーが存在します</h4>
-      <% @duplicated_alerts.each do |alert| %>
+      <% duplicated_customer_alerts.each do |alert| %>
         <li><%= link_to alert[:message], customers_duplicate_index_path(columns: alert[:columns]) %></li>
       <% end %>
     </div>

--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -51,3 +51,20 @@ domain:
 
 customer:
   common_email: 'common.mail@olivebodycare.healthcare'
+
+duplicated_customer:
+  kana: 
+    name: 'カナ'
+    columns:
+      - first_kana
+      - last_kana
+  tel:
+    name: '電話番号'
+    columns:
+      - tel
+  kana_tel:
+    name: 'カナと電話番号'
+    columns:
+      - first_kana
+      - last_kana
+      - tel


### PR DESCRIPTION
## 概要
重複アラートを表示する件で以下の追加対応
```
・重複条件の変更が必要。
・以下の３つが欲しい
　・カナが一致
　・電話番号が一致
　・電話番番号とカナの両方が一致
```

## Trello
重複アラート機能の追加実装 ( https://trello.com/c/UtSHmLx0 )