### PR TITLE
顧客基本情報画面に表示項目を追加。

### DIFF
--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -104,7 +104,7 @@ class CustomersController < ApplicationController
         :tel, :fixed_line_tel, :display_email, :can_receive_mail,
         :first_visit_store_id, :first_visited_at, :last_visit_store_id, :comment,
         :zip_code, :address, :birthday, :card_number, :has_registration_card,
-        :introducer, :children_count, :baby_age_id,
+        :introducer, :visit_reason_id, :nearest_station_id, :searchd_by, :children_count, :baby_age_id,
         :occupation_id, :zoomancy_id, :size_id, :provider, :password, :is_deleted        
       )
     end

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -104,7 +104,7 @@ class CustomersController < ApplicationController
         :tel, :fixed_line_tel, :display_email, :can_receive_mail,
         :first_visit_store_id, :first_visited_at, :last_visit_store_id, :comment,
         :zip_code, :address, :birthday, :card_number, :has_registration_card,
-        :introducer, :visit_reason_id, :nearest_station_id, :searchd_by, :children_count, :baby_age_id,
+        :introducer, :visit_reason_id, :nearest_station_id, :searched_by, :children_count, :baby_age_id,
         :occupation_id, :zoomancy_id, :size_id, :provider, :password, :is_deleted        
       )
     end

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -124,7 +124,7 @@
         default: @customer.nearest_station_id,
         include_blank: true
       ) %>
-      <%= f.input :searchd_by, label: 'Web検索'%>
+      <%= f.input :searched_by, label: 'Web検索'%>
       <%= f.input :children_count, label: 'お子様の数'%>
       <%= f.input(
         :baby_age_id,

--- a/src/app/views/customers/_form.html.erb
+++ b/src/app/views/customers/_form.html.erb
@@ -108,6 +108,23 @@
         include_blank: true
       ) %>
       <%= f.input :introducer, label: '紹介者' %>
+      <%= f.input(
+        :visit_reason_id,
+        as: :select,
+        collection: @visit_reasons.map{ |item| [item.name, item.id] },
+        label: '来店経緯',
+        default: @customer.visit_reason_id,
+        include_blank: true
+      ) %>
+      <%= f.input(
+        :nearest_station_id,
+        as: :select,
+        collection: @nearest_stations.map{ |item| [item.name, item.id] },
+        label: '最寄駅',
+        default: @customer.nearest_station_id,
+        include_blank: true
+      ) %>
+      <%= f.input :searchd_by, label: 'Web検索'%>
       <%= f.input :children_count, label: 'お子様の数'%>
       <%= f.input(
         :baby_age_id,

--- a/src/db/migrate/20200310081713_rename_searchd_by_column_to_customers.rb
+++ b/src/db/migrate/20200310081713_rename_searchd_by_column_to_customers.rb
@@ -1,0 +1,5 @@
+class RenameSearchdByColumnToCustomers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :customers, :searchd_by, :searched_by
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_144418) do
+ActiveRecord::Schema.define(version: 2020_03_10_081713) do
 
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_144418) do
     t.date "last_visited_at"
     t.string "card_number", comment: "カルテの番号。紙媒体で管理しているため、外部キーなし"
     t.string "introducer", comment: "紹介していただいた方の名前など"
-    t.string "searchd_by", comment: "web検索単語など"
+    t.string "searched_by", comment: "web検索単語など"
     t.boolean "has_registration_card", comment: "診察券を発行したかどうか"
     t.integer "children_count", comment: "お子様の数。その他やdefault値にあたるものはnullにする"
     t.datetime "created_at", null: false

--- a/src/db/seeds/test/20190426_store_customer_staff_seeds.rb
+++ b/src/db/seeds/test/20190426_store_customer_staff_seeds.rb
@@ -47,7 +47,7 @@ customer = Customer.where(id: 1).first_or_create!(
   baby_age_id: 1,
   visit_reason_id: 1,
   introducer: '山田',
-  searchd_by: 'オリーブ',
+  searched_by: 'オリーブ',
   nearest_station_id: 1,
   size_id: 1,
   has_registration_card: false

--- a/src/db/seeds/test/20190608_customer_faker.rb
+++ b/src/db/seeds/test/20190608_customer_faker.rb
@@ -28,7 +28,7 @@ customer = 41.times do |n|
     baby_age_id: 1,
     visit_reason_id: 1,
     introducer: '山田',
-    searchd_by: 'オリーブ',
+    searched_by: 'オリーブ',
     nearest_station_id: 1,
     size_id: 1,
     has_registration_card: false


### PR DESCRIPTION
### 変更内容

・顧客基本情報画面（/customers/id）に来店経緯、最寄駅、Web検索の表示項目を追加。

・customers_controllerのストロングパラメータに追加した表示項目を追加。

・customersテーブルのカラム名の変更 (searchd＿by => searched_by)