### PR TITLE
【管理画面】スタッフ一覧画面　店舗検索時エラー #176

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
   # 店舗に応じたスタッフを選択可能にする
   def viewable_staffs
     store_ids = viewable_stores.pluck(:id)
-    return Staff.where_store_id(store_ids).uniq
+    return Staff.where_store_id(store_ids).distinct
   end
 
   # 管理者のみ管理者権限に変更できるようにする


### PR DESCRIPTION
#176
uniqからdistinctに変更したことで、戻り値の型がArrayからActiveRecord::Relationに変更しました。
viewable_staffsの戻り値を使っている箇所は他に
- 予約一覧画面　検索条件の担当者の選択肢
- シフト登録画面　登録対象の担当者の選択肢
がありました。
こちらの画面を正常に動作することを確認したので、今回の修正で問題ないと思っています。

ご確認お願いします。