### PR TITLE
【経過記録】来店時刻をブランクで登録した時にエラーが出るのを修正

### DIFF
--- a/src/app/views/observations/_form.html.erb
+++ b/src/app/views/observations/_form.html.erb
@@ -1,5 +1,9 @@
 <div class="form-wrapper">
-  <%= simple_form_for(@observation, wrapper: :horizontal_form, html: { class: 'form-horizontal', autocomplete: 'off' }) do |f|%>
+  <%= simple_form_for(
+    @observation,
+    wrapper: :horizontal_form,
+    html: { class: 'form-horizontal', autocomplete: 'off' }
+  ) do |f|%>
     <%= render 'application/form_error', errors: @observation.errors %>
 
     <div class="form-center">
@@ -12,7 +16,7 @@
         label: '来店店舗',
         default: @observation.store_id,
         include_blank: true,
-        required: true
+        required: @observation.new_record?
       )%>
       <div class="row">
         <label class="col-sm-3">
@@ -44,7 +48,7 @@
         label: '担当者',
         default: @observation.staff_id,
         include_blank: true,
-        required: true
+        required: @observation.new_record?
       )%>
       <%= f.input(
         :menu_id,
@@ -53,7 +57,7 @@
         label: 'メニュー',
         default: @observation.menu_id,
         include_blank: true,
-        required: true
+        required: @observation.new_record?
       )%>
       <div class="form-group row">
         <label class="col-sm-3">オプション</label>

--- a/src/app/views/observations/_form.html.erb
+++ b/src/app/views/observations/_form.html.erb
@@ -11,16 +11,21 @@
         collection: @stores.map{|store| [store.name, store.id] },
         label: '来店店舗',
         default: @observation.store_id,
-        include_blank: true
+        include_blank: true,
+        required: true
       )%>
       <div class="row">
-        <label class="col-sm-3">来店日</label>
+        <label class="col-sm-3">
+          来店日
+          <abbr class="req">&nbsp;(必須)</abbr>
+        </label>
         <div class="col-sm-9">
           <%= f.input(
             :visit_date,
             as: :date,
             label: false,
-            default: Date.today
+            default: Date.today,
+            required: true
           ) %>
         </div>
       </div>
@@ -29,7 +34,8 @@
         collection: Settings.stores.time_options,
         as: :select,
         label: '来店時刻',
-        include_blank: false
+        include_blank: true,
+        required: true
       ) %>
       <%= f.input(
         :staff_id,
@@ -37,7 +43,8 @@
         collection: @staffs.map{|staff| [staff.name, staff.id] },
         label: '担当者',
         default: @observation.staff_id,
-        include_blank: true
+        include_blank: true,
+        required: true
       )%>
       <%= f.input(
         :menu_id,
@@ -45,7 +52,8 @@
         collection: @menus.map{|menu| [menu.name, menu.id] },
         label: 'メニュー',
         default: @observation.menu_id,
-        include_blank: true
+        include_blank: true,
+        required: true
       )%>
       <div class="form-group row">
         <label class="col-sm-3">オプション</label>

--- a/src/app/views/observations/_form.html.erb
+++ b/src/app/views/observations/_form.html.erb
@@ -42,7 +42,8 @@
         :visit_time,
         collection: Settings.stores.time_options,
         as: :select,
-        label: '来店時刻'
+        label: '来店時刻',
+        include_blank: false
       ) %>
       <%= f.input(
         :staff_id,

--- a/src/app/views/observations/_list.html.erb
+++ b/src/app/views/observations/_list.html.erb
@@ -23,7 +23,7 @@
           <tr>
             <td><%= observation.id %></td>
             <td><%= observation.store.name %></td>
-            <td><%= observation.visit_datetime.strftime('%Y-%m-%d %H:%M') %></td>
+            <td><%= observation.visit_datetime.present? ? observation.visit_datetime.strftime('%Y-%m-%d %H:%M') : '' %></td>
             <td><%= observation.staff.present? ? observation.staff.full_name : '' %></td>
             <td><%= observation.menu.name %></td>
             <td><%= observation.options.present? ? safe_join(observation.option_names, tag(:br)) : '無' %></td></td>


### PR DESCRIPTION
#### 修正内容
- 来店日時がブランクの時に経過記録一覧でエラーになるのを修正
- 来店日時の時刻から、ブランクの選択肢を除く
　　現状だと、時刻がブランクだと日付の選択をしても来店日時がnullで登録されていました。
　　この修正か、時刻がブランクの場合に時刻を00:00で登録する修正もありかと思いましたが、顧客が何時に来店したか分からなくなるケースはないかと思って今回の修正にしています。

※外部キーの設定変更はプルリクを分けて対応します。