### PR TITLE
顧客統合タスク修正

### DIFF
--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -27,7 +27,7 @@ class Customer < ApplicationRecord
   belongs_to :size, optional: true
   belongs_to :visit_reason, optional: true
   belongs_to :nearest_station, optional: true
-  belongs_to :medical_record, optional: true
+  has_one :medical_record
 
   has_many :reservations
   has_many :observations

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -72,6 +72,7 @@ class Customer < ApplicationRecord
   def self.merge(merge_from_id, merge_to_id)
     merge_from_customer = find(merge_from_id)
     merge_from_customer.reservations.update(customer_id: merge_to_id)
+    merge_from_customer.observations.update(customer_id: merge_to_id)
 
     merge_to_customer = find(merge_to_id)
 

--- a/src/lib/tasks/customer.rake
+++ b/src/lib/tasks/customer.rake
@@ -27,6 +27,44 @@ namespace :customer do
     }
   end
 
+  desc '顧客統合CSVにエラーがないかチェックする'
+  task :check_customers_in_csv, [:csv_path] => :environment do |task, args|
+    csv_full_path = Rails.root.join args[:csv_path]
+    check_customers_in_csv(csv_full_path)
+  end
+
+  def check_customers_in_csv(csv_file_path)
+    csv = CSV.table(csv_file_path, headers: :first_row, encoding: 'Shift_JIS:UTF-8')
+    headers = csv.headers
+
+    is_error = false
+    customer_ids = []
+    csv.each_with_index { |row, csv_index|
+      row_num = csv_index + 2
+      (0...headers.length).filter { |i|
+        (headers[i] == :merge_from || headers[i] == :merge_to) && row[i].present?
+      }.each { |i|
+        customer_id = row[i]
+        if customer_ids.include?(customer_id)
+          puts "ERROR IDが重複しています。ID：#{customer_id}"
+          is_error = true
+        end
+        customer_ids.push(customer_id)
+        customer_relation = Customer.where(id: customer_id)
+        if !customer_relation.exists?
+          puts "ERROR #{row_num}行目：対象のIDの顧客が存在しません。ID：#{customer_id}"
+          is_error = true
+        elsif headers[i] == :merge_to && customer_relation.where_deleted(true).exists?
+          puts "ERROR #{row_num}行目：未使用の顧客が統合先に指定されています。ID：#{customer_id}"
+          is_error = true
+        elsif headers[i] == :merge_from && customer_relation.first.medical_record.present?
+          puts "WARNING #{row_num}行目：問診票が登録済みです。問診票は自動で統合できません。ID：#{customer_id}"
+        end
+      }
+    }
+    puts 'SUCCESS CSVファイルにエラーはありませんでした。' unless is_error
+  end
+
   desc '非会員登録した顧客を一括で会員に変更する'
   task :migrate_to_member, [:password] => :environment do |task, args|
     Customer.transaction do


### PR DESCRIPTION
@nuno929 
https://eggsystem.slack.com/archives/CE4J879LN/p1588296188000500
カルテは顧客に1:1で紐づくレコードなので、移行対象にするのは難しいかと思ってしていません。
代わりにチェック用のコマンドで、移行元顧客にカルテが作成済みだとアラートを出すようにしています。
ご確認お願いします。