### PR TITLE
予約更新時に、シフトの空いているスタッフのみを表示する対応

### DIFF
--- a/build.command
+++ b/build.command
@@ -1,3 +1,6 @@
 # デプロイ用のソースコードを作成するためのバッチ
 cd `dirname $0`
+rm -rf src/public/assets/javascripts/webpack
+mkdir src/public/assets/javascripts/webpack
+yarn prod
 zip src.zip -r src/* src/.[^.]* -x src/.env src/tmp/\*

--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -1,8 +1,12 @@
 import { renderCalendar } from './render/calendar'
 import { renderShiftCheckboxes } from './render/shifts-checkboxes'
+import { renderAssignableStaffSelect } from './render/assignable-staff-select'
 
 // カレンダーの描画処理
 renderCalendar()
 
 // シフト用のチェックボックスの描画処理
 renderShiftCheckboxes()
+
+// シフトの空いているスタッフのみのセレクトボックスの描画処理
+renderAssignableStaffSelect()

--- a/frontend/class/AssignableStaffSelect.tsx
+++ b/frontend/class/AssignableStaffSelect.tsx
@@ -1,0 +1,183 @@
+import React, { ChangeEvent } from 'react'
+import FormControl from '@material-ui/core/FormControl'
+import Select from '@material-ui/core/Select'
+import MenuItem from '@material-ui/core/MenuItem'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import SelectStyle from '../styles/AssignedStaffSelectInput.scss'
+
+interface StaffJson {
+  id: string
+  last_name: string
+  first_name: string
+}
+
+interface Staff {
+  id: string
+  name: string
+}
+
+interface SelectOption {
+  label: string
+  value: string
+  disabled?: boolean
+}
+
+interface AssignedElement {
+  key: string
+  value: JQuery<HTMLInputElement>
+}
+
+interface StaffSelectProp {
+  selectedStaffOption: Staff | null
+  assignedElements: AssignedElement[]
+  disabled: boolean
+  hint: string
+}
+
+interface StaffSelectState {
+  selectedStaffId: string
+  staffs: Staff[] | null
+  selectedStaffOption: Staff | null
+  assignedElements: AssignedElement[]
+  disabled: boolean
+  hint: string
+  loading: boolean
+}
+
+export default class AssignableStaffSelect extends React.Component<
+  StaffSelectProp,
+  StaffSelectState
+> {
+  constructor(props: StaffSelectProp) {
+    super(props)
+
+    const selectedStaffId = props.selectedStaffOption
+      ? props.selectedStaffOption.id
+      : ''
+
+    this.state = {
+      selectedStaffId: selectedStaffId,
+      staffs: null,
+      selectedStaffOption: props.selectedStaffOption,
+      assignedElements: props.assignedElements,
+      disabled: props.disabled,
+      hint: props.hint,
+      loading: false
+    }
+  }
+
+  private staffOptions = (): SelectOption[] => {
+    if (this.state.selectedStaffOption) {
+      return [
+        { label: '担当スタッフを空にする', value: '' },
+        {
+          label: this.state.selectedStaffOption.name,
+          value: this.state.selectedStaffOption.id
+        }
+      ]
+    }
+
+    if (!this.state.staffs) {
+      return [{
+        label: 'エラーが発生しました。',
+        value: '',
+        disabled: true
+      }]
+    }
+
+    if (this.state.staffs.length === 0) {
+      return [{
+        label: 'シフトが空いている担当者がございません。',
+        value: '',
+        disabled: true
+      }]
+    }
+
+    return this.state.staffs.map((staff) => {
+      return { label: staff.name, value: staff.id }
+    })
+  }
+
+  private fetchStaffOptions = async () => {
+    const params = this.state.assignedElements.map((elementData) => {
+      if (elementData.value.length === 1) {
+        const paramValue = elementData.value.val()
+        return `${elementData.key}=${paramValue}`
+      }
+
+      return elementData.value.get().filter((element) => {
+        return element.checked
+      }).flatMap((element) => {
+        return `${elementData.key}=${element.value}`
+      }).join('&')
+    })
+
+    try {
+      this.setState({ loading: true })
+      const response = await fetch(`/api/admin/staffs?${params.join('&')}`)
+      const result = await response.json()
+      const staffs = result.map((staff: StaffJson) => {
+        return { id: staff.id, name: `${staff.last_name} ${staff.first_name}` }
+      })
+      this.setState({ staffs })
+    } catch (error) {
+      console.log('スタッフ取得時にエラーが発生しました。')
+      console.log(error)
+      this.setState({ staffs: null })
+    } finally {
+      this.setState({ loading: false })
+    }
+  }
+
+  public componentDidMount = async () => {
+    this.state.assignedElements.forEach((elementData) => {
+      elementData.value.on('change', this.fetchStaffOptions)
+    })
+
+    await this.fetchStaffOptions()
+  }
+
+  private handleSelectedStaffId = (
+    event: ChangeEvent<{ name?: string | undefined, value: unknown }>
+  ): void => {
+    this.setState({ selectedStaffId: event.target.value as string })
+  }
+
+  public render() {
+    return <FormControl disabled={ this.state.disabled }>
+      <Select
+        value={ this.state.selectedStaffId }
+        onChange={ this.handleSelectedStaffId }
+        disabled={ this.state.disabled }
+        className={ SelectStyle.assignedStaffSelect }
+      >
+        { this.state.loading && <MenuItem disabled>
+          <CircularProgress />
+        </MenuItem> }
+        { 
+          !this.state.loading
+            && this.staffOptions().map((option) => {
+              return <MenuItem
+                key={ option.value }
+                value={ option.value }
+                disabled={ option.disabled }
+              >
+                { option.label }
+              </MenuItem>
+            })
+        }
+      </Select>
+      {
+        this.state.hint
+          && <small className="form-text text-muted">
+            { this.state.hint }
+          </small>
+      }
+      <input
+        type="hidden"
+        name="reservation[staff_id]"
+        value={ this.state.selectedStaffId }
+      />
+    </FormControl>
+  }
+}

--- a/frontend/class/AssignableStaffSelect.tsx
+++ b/frontend/class/AssignableStaffSelect.tsx
@@ -130,6 +130,10 @@ export default class AssignableStaffSelect extends React.Component<
   }
 
   public componentDidMount = async () => {
+    if (this.state.selectedStaffOption) {
+      return
+    }
+
     this.state.assignedElements.forEach((elementData) => {
       elementData.value.on('change', this.fetchStaffOptions)
     })

--- a/frontend/class/CalendarInput.tsx
+++ b/frontend/class/CalendarInput.tsx
@@ -31,6 +31,11 @@ export default class CalendarInput extends React.Component<CalendarProp, Calenda
 
   public handleDateValue = (value: MaterialUiPickersDate) => {
     this.state.dateValueElement.value = value ? value?.format('YYYY-MM-DD') : ''
+
+    // 他のコンポーネントと連携しやすくするため、イベントを発生させる
+    const changeEvent = new Event('change', { bubbles: true })
+    this.state.dateValueElement.dispatchEvent(changeEvent)
+
     this.setState({ dateValueElement: this.state.dateValueElement })
   }
 

--- a/frontend/render/assignable-staff-select.tsx
+++ b/frontend/render/assignable-staff-select.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import $ from 'jquery'
+import AssignableStaffSelect from '../class/AssignableStaffSelect'
+
+const assignedElementQueries = [
+  { query: '#reservation_store_id', key: 'store_id' },
+  { query: '#react_reservation_date_value', key: 'reservation_date' },
+  { query: '#reservation_start_time', key: 'reseravtion_start_time' },
+  {
+    query: '[id^="reservation_reservation_details_attributes_"][id$="_menu_id"]',
+    key: 'reservation_menu_ids[]'
+  },
+  {
+    query: '[id^="reservation_reservation_details_attributes_"][id*="_option_ids_"]',
+    key: 'reservation_option_ids[]'
+  },
+]
+
+export const renderAssignableStaffSelect = () => {
+  const element = $('#react_reservation_assignable_staff_select')
+  if (Object.keys(element).length === 0) {
+    return
+  }
+
+  const disabledValue = element.data('disabled')
+  const hintValue = element.data('hint')
+  const selectedStaff = element.data('selected-staff')
+  const selectedStaffOption = selectedStaff
+    ? {
+      id: selectedStaff.id,
+      name: `${selectedStaff.last_name} ${selectedStaff.first_name}`
+    }
+    : null
+  const assignedElements = assignedElementQueries.map((element) => {
+    return {
+      key: element.key,
+      value: $(element.query) as JQuery<HTMLInputElement>
+    }
+  })
+
+  ReactDOM.render(
+    <AssignableStaffSelect
+      selectedStaffOption={ selectedStaffOption }
+      assignedElements={ assignedElements }
+      disabled={ disabledValue }
+      hint={ hintValue }
+    />,
+    element.get(0)
+  )
+}

--- a/frontend/styles/AssignedStaffSelectInput.scss
+++ b/frontend/styles/AssignedStaffSelectInput.scss
@@ -1,0 +1,7 @@
+.assignedStaffSelect {
+  min-width: 20rem;
+
+  :global(.MuiSelect-root) {
+    padding: 0.375rem 0.75rem;
+  }
+}

--- a/src/app/controllers/api/admin/staffs_controller.rb
+++ b/src/app/controllers/api/admin/staffs_controller.rb
@@ -1,0 +1,36 @@
+class Api::Admin::StaffsController < ApplicationController
+  def index
+    store_id = staff_params[:store_id]
+    date = staff_params[:reservation_date]
+    start_time = staff_params[:reseravtion_start_time]
+
+    assignable_staff_ids = Shift
+      .where_not_reserved()
+      .where(store_id: store_id)
+      .where(date: date)
+      .where(start_at: start_time)
+      .select(:staff_id)
+      .distinct()
+      .pluck(:staff_id)
+
+    menu_ids = staff_params[:reservation_menu_ids]
+    option_ids = staff_params[:reservation_option_ids]
+
+    staffs = Staff
+      .where(id: assignable_staff_ids)
+      .can_treats(menu_ids, option_ids)
+
+    render json: staffs
+  end
+
+  # shiftのあるスタッフを検索する
+  def staff_params
+    return params.permit(
+      :store_id,
+      :reservation_date,
+      :reseravtion_start_time,
+      reservation_menu_ids: [], 
+      reservation_option_ids: [],
+    )
+  end
+end

--- a/src/app/controllers/api/admin/staffs_controller.rb
+++ b/src/app/controllers/api/admin/staffs_controller.rb
@@ -1,36 +1,40 @@
-class Api::Admin::StaffsController < ApplicationController
-  def index
-    store_id = staff_params[:store_id]
-    date = staff_params[:reservation_date]
-    start_time = staff_params[:reseravtion_start_time]
+module Api
+  module Admin
+    class StaffsController < ApplicationController
+      def index
+        store_id = staff_params[:store_id]
+        date = staff_params[:reservation_date]
+        start_time = staff_params[:reseravtion_start_time]
 
-    assignable_staff_ids = Shift
-      .where_not_reserved()
-      .where(store_id: store_id)
-      .where(date: date)
-      .where(start_at: start_time)
-      .select(:staff_id)
-      .distinct()
-      .pluck(:staff_id)
+        assignable_staff_ids = Shift
+          .where_not_reserved
+          .where(store_id: store_id)
+          .where(date: date)
+          .where(start_at: start_time)
+          .select(:staff_id)
+          .distinct
+          .pluck(:staff_id)
 
-    menu_ids = staff_params[:reservation_menu_ids]
-    option_ids = staff_params[:reservation_option_ids]
+        menu_ids = staff_params[:reservation_menu_ids]
+        option_ids = staff_params[:reservation_option_ids]
 
-    staffs = Staff
-      .where(id: assignable_staff_ids)
-      .can_treats(menu_ids, option_ids)
+        staffs = Staff
+          .where(id: assignable_staff_ids)
+          .can_treats(menu_ids, option_ids)
 
-    render json: staffs
-  end
+        render json: staffs
+      end
 
-  # shiftのあるスタッフを検索する
-  def staff_params
-    return params.permit(
-      :store_id,
-      :reservation_date,
-      :reseravtion_start_time,
-      reservation_menu_ids: [], 
-      reservation_option_ids: [],
-    )
+      # shiftのあるスタッフを検索する
+      def staff_params
+        return params.permit(
+          :store_id,
+          :reservation_date,
+          :reseravtion_start_time,
+          reservation_menu_ids: [],
+          reservation_option_ids: []
+        )
+      end
+    end
   end
 end

--- a/src/app/models/staff.rb
+++ b/src/app/models/staff.rb
@@ -57,7 +57,7 @@ class Staff < ApplicationRecord
   }
 
   # 店舗idによる絞り込み
-  scope :where_store_id, ->(store_id) {
+  scope :where_store_id, -> (store_id) {
     joins(:stores).merge(Store.where(id: store_id))
   }
 

--- a/src/app/models/staff.rb
+++ b/src/app/models/staff.rb
@@ -57,7 +57,7 @@ class Staff < ApplicationRecord
   }
 
   # 店舗idによる絞り込み
-  scope :where_store_id, -> (store_id) {
+  scope :where_store_id, ->(store_id) {
     joins(:stores).merge(Store.where(id: store_id))
   }
 

--- a/src/app/views/customers/_table.html.erb
+++ b/src/app/views/customers/_table.html.erb
@@ -11,7 +11,7 @@
       <th scope="col">サイズ</th>
       <th scope="col">診察券</th>
       <th scope="col">初回ご来店日</th>
-      <th scope="col">予約登録者</th>
+      <th scope="col">使用状況</th>
       <th scope="col"></th>
     </tr>
   </thead>

--- a/src/app/views/reservations/fields/_assined_inputs.html.erb
+++ b/src/app/views/reservations/fields/_assined_inputs.html.erb
@@ -1,11 +1,20 @@
-<%= form.input(
-  :staff_id,
-  collection: is_assigned ? [@reservation.staff] : @staffs,
-  label: '担当スタッフ',
-  include_blank: true,
-  disabled: @reservation.new_record? || @reservation.canceled?,
-  hint: @reservation.new_record? ? '日時、メニューを元に自動で割当てられます。' : ''
-) %>
+<div class="form-group row select">
+  <label class="col-sm-3 col-form-label select" for="reservation_staff_id">
+    担当スタッフ
+  </label>
+  <div class="col-sm-9">
+    <div
+      id="react_reservation_assignable_staff_select"
+      data-disabled="<%= @reservation.new_record? || @reservation.canceled? %>"
+      data-hint="<%=
+        @reservation.new_record? ? '日時、メニューを元に自動で割当てられます。' : ''
+      %>"
+      data-selected-staff="<%=
+        is_assigned ? @reservation.staff.to_json : ''
+      %>"
+    ></div>
+  </div>
+</div>
 
 <%= form.input(
   :store_id,

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -60,6 +60,9 @@ Rails.application.routes.draw do
     get 'shops(/:id)/dates', to: 'stores#dates'
 
     resources :reservations, only: [:create, :index, :show, :destroy]
+
+    namespace :admin do
+      resources :staffs, only: [:index]
+    end
   end
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 対応内容
- 描画処理の実装
- デザイン微調整
- ロード中やエラーなどの発生時の処理を実装
- スタッフ検索のAPIを実装