### PR TITLE
予約日の範囲検索カレンダーを日曜日からにする

### DIFF
--- a/frontend/class/CalendarSearcInput.tsx
+++ b/frontend/class/CalendarSearcInput.tsx
@@ -9,11 +9,17 @@ import Dialog from '@material-ui/core/Dialog'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import DialogContent from '@material-ui/core/DialogContent'
 import DialogActions from '@material-ui/core/DialogActions'
-import Grid from '@material-ui/core/Grid';
+import Grid from '@material-ui/core/Grid'
 import Button from '@material-ui/core/Button'
 
 // 日本語化のため使用
-import ja from 'date-fns/locale/ja';
+import ja from 'date-fns/locale/ja'
+
+// カレンダーを日曜日から表示するようにする
+ja.options = {
+  ...ja.options,
+  weekStartsOn: 0
+}
 
 import moment, { Moment } from 'moment'
 


### PR DESCRIPTION
## 対応内容
- 範囲検索のカレンダーを月曜始まりから、日曜始まりに変更