### PR TITLE
顧客検索にカナ検索追加

### DIFF
--- a/src/app/controllers/concerns/reservation_searchable.rb
+++ b/src/app/controllers/concerns/reservation_searchable.rb
@@ -7,6 +7,7 @@ module Concerns::ReservationSearchable
     reservations = reservations.order('id DESC')
 
     reservations = reservations.like_customer_name(@customer_name) if @customer_name.present?
+    reservations = reservations.like_customer_kana_name(@customer_kana_name) if @customer_kana_name.present?
     reservations = reservations.like_customer_tel(@customer_tel) if @customer_tel.present?
 
     reservations = reservations.where('reservation_date >= ?', @from_date) if @from_date.present?

--- a/src/app/controllers/concerns/reservation_searchable.rb
+++ b/src/app/controllers/concerns/reservation_searchable.rb
@@ -6,9 +6,9 @@ module Concerns::ReservationSearchable
     reservations = reservations.order_reserved_at if @order === 'reserved_at'
     reservations = reservations.order('id DESC')
 
-    reservations = reservations.like_customer_name(@customer_name) if @customer_name.present?
-    reservations = reservations.like_customer_kana_name(@customer_kana_name) if @customer_kana_name.present?
-    reservations = reservations.like_customer_tel(@customer_tel) if @customer_tel.present?
+    reservations = reservations.like_customer_name(@customer_name)
+    reservations = reservations.like_customer_kana_name(@customer_kana_name)
+    reservations = reservations.like_customer_tel(@customer_tel)
 
     reservations = reservations.where('reservation_date >= ?', @from_date) if @from_date.present?
     reservations = reservations.where('reservation_date <= ?', @to_date) if @to_date.present?

--- a/src/app/controllers/customers_controller.rb
+++ b/src/app/controllers/customers_controller.rb
@@ -11,6 +11,7 @@ class CustomersController < ApplicationController
 
     # like検索ではパラメータチェックは不要
     @customers = @customers.like_name(@search_params[:name])
+    @customers = @customers.like_kana_name(@search_params[:kana_name])
     @customers = @customers.like_tel(@search_params[:tel])
     @customers = @customers.like_email(@search_params[:email])
 
@@ -136,6 +137,6 @@ class CustomersController < ApplicationController
   end
 
   def search_params
-    params.permit(:name, :tel, :email, :include_deleted, :page)
+    params.permit(:name, :kana_name, :tel, :email, :include_deleted, :page)
   end
 end

--- a/src/app/controllers/reservations_controller.rb
+++ b/src/app/controllers/reservations_controller.rb
@@ -19,6 +19,7 @@ class ReservationsController < ApplicationController
     @staff_id = params[:staff_id]
 
     @customer_name = params[:customer_name]
+    @customer_kana_name = params[:customer_kana_name]
     @customer_tel = params[:customer_tel]
 
     @from_date = Date.parse(params[:from_date]) if params.has_key?(:from_date)
@@ -31,6 +32,7 @@ class ReservationsController < ApplicationController
   def search
     redirect_to reservations_path({
       customer_name: params[:customer_name],
+      customer_kana_name: params[:customer_kana_name],
       customer_tel: params[:customer_tel],
       state: params[:state],
       staff_id: params[:staff_id],

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -50,6 +50,10 @@ class Customer < ApplicationRecord
     where("concat(last_name, first_name) like ?", "%#{name}%") if name.present?
   }
 
+  scope :like_kana_name, ->(kana_name) {
+    where("concat(last_kana, first_kana) like ?", "%#{kana_name}%") if kana_name.present?
+  }
+
   scope :like_tel, ->(tel) {
     where('tel LIKE ?', "%#{tel}%") if tel.present?
   }

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -51,7 +51,7 @@ class Customer < ApplicationRecord
   }
 
   scope :like_kana_name, ->(kana_name) {
-    where("concat(last_kana, first_kana) like ?", "%#{kana_name}%") if kana_name.present?
+    where("concat(last_kana, first_kana) collate utf8_unicode_ci like ?", "%#{kana_name}%") if kana_name.present?
   }
 
   scope :like_tel, ->(tel) {

--- a/src/app/models/reservation.rb
+++ b/src/app/models/reservation.rb
@@ -37,6 +37,10 @@ class Reservation < ApplicationRecord
     joins(:customer).where("concat(last_name, first_name) like ?", "%#{customer_name}%")
   }
 
+  scope :like_customer_kana_name, ->(customer_kana_name) {
+    joins(:customer).merge(Customer.like_kana_name(customer_kana_name))
+  }
+
   scope :like_customer_tel, ->(customer_tel) {
     joins(:customer).where("tel like ?", "%#{customer_tel}%")
   }

--- a/src/app/models/reservation.rb
+++ b/src/app/models/reservation.rb
@@ -34,7 +34,7 @@ class Reservation < ApplicationRecord
   validate :validate_reservation_date, on: :create
 
   scope :like_customer_name, ->(customer_name) {
-    joins(:customer).where("concat(last_name, first_name) like ?", "%#{customer_name}%")
+    joins(:customer).merge(Customer.like_name(customer_name))
   }
 
   scope :like_customer_kana_name, ->(customer_kana_name) {
@@ -42,7 +42,7 @@ class Reservation < ApplicationRecord
   }
 
   scope :like_customer_tel, ->(customer_tel) {
-    joins(:customer).where("tel like ?", "%#{customer_tel}%")
+    joins(:customer).merge(Customer.like_tel(customer_tel))
   }
 
   scope :order_reserved_at, ->(order = :desc) {

--- a/src/app/models/reservation.rb
+++ b/src/app/models/reservation.rb
@@ -34,15 +34,15 @@ class Reservation < ApplicationRecord
   validate :validate_reservation_date, on: :create
 
   scope :like_customer_name, ->(customer_name) {
-    joins(:customer).merge(Customer.like_name(customer_name))
+    joins(:customer).merge(Customer.like_name(customer_name)) if customer_name.present?
   }
 
   scope :like_customer_kana_name, ->(customer_kana_name) {
-    joins(:customer).merge(Customer.like_kana_name(customer_kana_name))
+    joins(:customer).merge(Customer.like_kana_name(customer_kana_name)) if customer_kana_name.present?
   }
 
   scope :like_customer_tel, ->(customer_tel) {
-    joins(:customer).merge(Customer.like_tel(customer_tel))
+    joins(:customer).merge(Customer.like_tel(customer_tel)) if customer_tel.present?
   }
 
   scope :order_reserved_at, ->(order = :desc) {

--- a/src/app/views/customers/_table.html.erb
+++ b/src/app/views/customers/_table.html.erb
@@ -4,6 +4,7 @@
       <th scope="col">顧客ID</th>
       <th scope="col">FMID</th>
       <th scope="col">氏名</th>
+      <th scope="col">カナ氏名</th>
       <th class="address" scope="col">住所</th>
       <th scope="col">TEL</th>
       <th scope="col">Email</th>
@@ -21,6 +22,7 @@
         <td scope="row"><%= customer.id %></td>
         <td scope="row"><%= customer.fmid %></td>
         <td><%= customer.last_name + customer.first_name %></td>
+        <td><%= customer.last_kana + customer.first_kana %></td>
         <td class="address"><%= customer.address %></td>
         <td><%= customer.tel %></td>
         <td><%= customer.display_email %></td>

--- a/src/app/views/customers/_table.html.erb
+++ b/src/app/views/customers/_table.html.erb
@@ -1,6 +1,5 @@
-<div class="table-responsive text-nowrap">
-  <table class="table">
-    <thead class="thead-light">
+<table class="table">
+  <thead class="thead-light">
     <tr>
       <th scope="col">顧客ID</th>
       <th scope="col">FMID</th>
@@ -16,8 +15,8 @@
       <th scope="col">使用状況</th>
       <th scope="col"></th>
     </tr>
-    </thead>
-    <tbody>
+  </thead>
+  <tbody>
     <% customers.each do |customer| %>
       <tr>
         <td scope="row"><%= customer.id %></td>
@@ -41,6 +40,5 @@
         </td>
       </tr>
     <% end %>
-    </tbody>
-  </table>
-</div>
+  </tbody>
+</table>

--- a/src/app/views/customers/_table.html.erb
+++ b/src/app/views/customers/_table.html.erb
@@ -21,8 +21,8 @@
       <tr>
         <td scope="row"><%= customer.id %></td>
         <td scope="row"><%= customer.fmid %></td>
-        <td><%= customer.last_name + customer.first_name %></td>
-        <td><%= customer.last_kana + customer.first_kana %></td>
+        <td><%= customer.full_name %></td>
+        <td><%= customer.full_kana %></td>
         <td class="address"><%= customer.address %></td>
         <td><%= customer.tel %></td>
         <td><%= customer.display_email %></td>

--- a/src/app/views/customers/_table.html.erb
+++ b/src/app/views/customers/_table.html.erb
@@ -1,5 +1,6 @@
-<table class="table">
-  <thead class="thead-light">
+<div class="table-responsive text-nowrap">
+  <table class="table">
+    <thead class="thead-light">
     <tr>
       <th scope="col">顧客ID</th>
       <th scope="col">FMID</th>
@@ -15,8 +16,8 @@
       <th scope="col">使用状況</th>
       <th scope="col"></th>
     </tr>
-  </thead>
-  <tbody>
+    </thead>
+    <tbody>
     <% customers.each do |customer| %>
       <tr>
         <td scope="row"><%= customer.id %></td>
@@ -40,5 +41,6 @@
         </td>
       </tr>
     <% end %>
-  </tbody>
-</table>
+    </tbody>
+  </table>
+</div>

--- a/src/app/views/customers/_table.html.erb
+++ b/src/app/views/customers/_table.html.erb
@@ -4,7 +4,7 @@
       <th scope="col">顧客ID</th>
       <th scope="col">FMID</th>
       <th scope="col">氏名</th>
-      <th scope="col">カナ氏名</th>
+      <th scope="col">カナ</th>
       <th class="address" scope="col">住所</th>
       <th scope="col">TEL</th>
       <th scope="col">Email</th>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -27,7 +27,7 @@
             <td>
           </tr>
           <tr>
-            <th>カナ氏名</th>
+            <th>カナ</th>
             <td>
               <%= f.text_field :kana_name, { class: "form-control", value: @search_params["kana_name"] } %>
             <td>

--- a/src/app/views/customers/index.html.erb
+++ b/src/app/views/customers/index.html.erb
@@ -23,7 +23,13 @@
           <tr>
             <th>氏名</th>
             <td>
-              <%=f.text_field :name, { class: "form-control", value: @search_params["name"] } %>
+              <%= f.text_field :name, { class: "form-control", value: @search_params["name"] } %>
+            <td>
+          </tr>
+          <tr>
+            <th>カナ氏名</th>
+            <td>
+              <%= f.text_field :kana_name, { class: "form-control", value: @search_params["kana_name"] } %>
             <td>
           </tr>
           <tr>

--- a/src/app/views/reservations/_list.html.erb
+++ b/src/app/views/reservations/_list.html.erb
@@ -12,8 +12,7 @@
           <th scope="col" class="reservation-date">予約日時</th>
           <th scope="col" class="visited_store">来店店舗</th>
           <% if is_shown_customer_name %>
-            <th scope="col">顧客名<br>(電話番号)</th>
-            <th scope="col">顧客カナ名</th>
+            <th scope="col">顧客</th>
           <% end %>
           <th scope="col">担当者</th>
           <th scope="col" class="gross-profit">売上金</th>
@@ -46,10 +45,9 @@
             <td rowspan="<%= row_span %>" class="visited_store"><%= reservation.store.name %></td>
             <% if is_shown_customer_name %>
               <td rowspan="<%= row_span %>">
-                <%= reservation.customer.full_name %><br>(<%= reservation.customer.tel %>)
-              </td>
-              <td rowspan="<%= row_span %>">
-                <%= reservation.customer.full_kana %>
+                氏名：<%= reservation.customer.full_name %><br>
+                カナ：<%= reservation.customer.full_kana %><br>
+                電話番号：<%= reservation.customer.tel %>
               </td>
             <% end %>
             <td rowspan="<%= row_span %>">

--- a/src/app/views/reservations/_list.html.erb
+++ b/src/app/views/reservations/_list.html.erb
@@ -13,6 +13,7 @@
           <th scope="col" class="visited_store">来店店舗</th>
           <% if is_shown_customer_name %>
             <th scope="col">顧客名<br>(電話番号)</th>
+            <th scope="col">顧客カナ名</th>
           <% end %>
           <th scope="col">担当者</th>
           <th scope="col" class="gross-profit">売上金</th>
@@ -46,6 +47,9 @@
             <% if is_shown_customer_name %>
               <td rowspan="<%= row_span %>">
                 <%= reservation.customer.full_name %><br>(<%= reservation.customer.tel %>)
+              </td>
+              <td rowspan="<%= row_span %>">
+                <%= reservation.customer.full_kana %>
               </td>
             <% end %>
             <td rowspan="<%= row_span %>">

--- a/src/app/views/reservations/_list.html.erb
+++ b/src/app/views/reservations/_list.html.erb
@@ -45,9 +45,9 @@
             <td rowspan="<%= row_span %>" class="visited_store"><%= reservation.store.name %></td>
             <% if is_shown_customer_name %>
               <td rowspan="<%= row_span %>">
-                氏名：<%= reservation.customer.full_name %><br>
-                カナ：<%= reservation.customer.full_kana %><br>
-                電話番号：<%= reservation.customer.tel %>
+                <%= reservation.customer.full_name %><br>
+                <%= reservation.customer.full_kana %><br>
+                <%= reservation.customer.tel %>
               </td>
             <% end %>
             <td rowspan="<%= row_span %>">

--- a/src/app/views/reservations/_search.html.erb
+++ b/src/app/views/reservations/_search.html.erb
@@ -46,7 +46,7 @@
           <td><%= form.text_field :customer_name, class: "form-control", value: @customer_name %></td>
         </tr>
         <tr>
-          <th>顧客カナ名</th>
+          <th>顧客カナ</th>
           <td><%= form.text_field :customer_kana_name, class: "form-control", value: @customer_kana_name %></td>
         </tr>
         <tr>

--- a/src/app/views/reservations/_search.html.erb
+++ b/src/app/views/reservations/_search.html.erb
@@ -46,6 +46,10 @@
           <td><%= form.text_field :customer_name, class: "form-control", value: @customer_name %></td>
         </tr>
         <tr>
+          <th>顧客カナ名</th>
+          <td><%= form.text_field :customer_kana_name, class: "form-control", value: @customer_kana_name %></td>
+        </tr>
+        <tr>
           <th>顧客電話番号</th>
           <td><%= form.text_field :customer_tel, class: "form-control", value: @customer_tel %></td>
         </tr>


### PR DESCRIPTION
# 概要

顧客画面でカタカナ検索をできるようにする

# 変更点

 - カナ氏名欄の追加
 - 顧客の表示テーブルにカナ氏名欄追加
 - 顧客の表示テーブルの文字の折返しをなくし、横スクロールできるように