### PR TITLE
非表示フラグの追加

### DIFF
--- a/src/app/controllers/api/admin/staffs_controller.rb
+++ b/src/app/controllers/api/admin/staffs_controller.rb
@@ -20,6 +20,7 @@ module Api
 
         staffs = Staff
           .where(id: assignable_staff_ids)
+          .exclude_hidden
           .can_treats(menu_ids, option_ids)
 
         render json: staffs

--- a/src/app/models/staff.rb
+++ b/src/app/models/staff.rb
@@ -74,7 +74,7 @@ class Staff < ApplicationRecord
   }
 
   scope :exclude_hidden, -> {
-    where("hidden", false)
+    where(hidden: false)
   }
 
   # nameもfull_nameも使われているため、削除時には要注意

--- a/src/app/models/staff.rb
+++ b/src/app/models/staff.rb
@@ -73,6 +73,10 @@ class Staff < ApplicationRecord
     where("concat(last_name, first_name) like ?", "%#{full_name}%")
   }
 
+  scope :exclude_hidden, -> {
+    where("hidden", false)
+  }
+
   # nameもfull_nameも使われているため、削除時には要注意
   def name
     self.full_name

--- a/src/app/views/staffs/_form.html.erb
+++ b/src/app/views/staffs/_form.html.erb
@@ -49,10 +49,10 @@
         required: true
       ) %>
       <%= f.input :login, label: "ログインID", required: true %>
-
       <% if @staff.id === current_staff.id || current_staff.role.manager? %>
         <%= f.input :password, label: "パスワード", required: @staff.new_record? %>
       <% end %>
+      <%= f.input :hidden, wrapper: :horizontal_collection_inline, label: '予約登録時非表示', checked: @staff.hidden, include_hidden: false %>
       <div>
         <%= f.button :submit, class: 'btn btn-primary'%>
         <%= link_to '戻る', staffs_path, class: 'btn btn-light' %>

--- a/src/config/initializers/simple_form_bootstrap.rb
+++ b/src/config/initializers/simple_form_bootstrap.rb
@@ -190,7 +190,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'col-sm-3 form-control-label'
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :input, class: 'form-check-inline', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
       ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
     end

--- a/src/db/migrate/20210306064355_add_hidden_to_staffs.rb
+++ b/src/db/migrate/20210306064355_add_hidden_to_staffs.rb
@@ -1,0 +1,5 @@
+class AddHiddenToStaffs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :staffs, :hidden, :boolean, default: false
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_26_032722) do
+ActiveRecord::Schema.define(version: 2021_03_06_064355) do
 
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -402,6 +402,7 @@ ActiveRecord::Schema.define(version: 2020_04_26_032722) do
     t.string "login", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.datetime "remember_created_at"
+    t.boolean "hidden", default: false
     t.index ["login"], name: "index_staffs_on_login", unique: true
     t.index ["role_id"], name: "index_staffs_on_role_id"
   end


### PR DESCRIPTION
# 概要
妊娠や出産で一時的に離職するスタッフがいる。（出産後に復帰予定）
管理画面から予約登録する時、一時的に離職しているスタッフも選択肢に入ってしまうと間違えてしまうので、離職中のスタッフは予約登録時に選択できないようにしたい。

## スタッフマスタ
・「非表示フラグ」（チェックボックス）を新設
・デフォルトは「OFF」
## 予約登録
【フロントからお客様が予約したとき】
・対応不要
→シフトが登録されていないハズなので。
【管理画面からスタッフが予約したとき】
・予約登録時「非表示フラグ」がONのスタッフは選択対象外にする
・予約情報を更新する際も、「非表示フラグ」がONのスタッフはプルダウンの選択リストに表示させない
## 注意事項
・既に登録されている予約データには影響を及ぼさないこと
→スタッフAに対して非表示ONを設定しても、過去の予約データを開けば「担当スタッフA」と表示されること"