### PR TITLE
CIでRails環境構築失敗の修正

### DIFF
--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     method_source (1.0.0)
     mimemagic (0.3.7)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     mini_racer (0.3.1)
       libv8 (~> 8.4.255)
     minitest (5.14.2)
@@ -228,8 +228,9 @@ GEM
     multipart-post (2.1.1)
     mysql2 (0.5.3)
     nio4r (2.5.4)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.19.2)
     paranoia (2.4.2)
@@ -247,6 +248,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (3.12.6)
+    racc (1.5.2)
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -452,4 +454,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.7)
+      nokogiri (~> 1.11.2)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -452,4 +452,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.16.6

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.7)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     mini_racer (0.3.1)


### PR DESCRIPTION
# 概要
mimemagicの0.3.5が消えたことによりエラーが出るようになった
https://twitter.com/ganta0087/status/1374722279133884416
https://qiita.com/Wacci6/items/dc6ffec9b50578d44d6c

`build-rails`の段階で失敗していたのを修正
rubocopのエラーはそのままです

# 変更内容

```
bundle update nokogiri
bundle update mimemagic
```