### PR TITLE
スタッフ管理、「選択時非表示」の表示追加

### DIFF
--- a/src/app/assets/stylesheets/application.scss
+++ b/src/app/assets/stylesheets/application.scss
@@ -48,3 +48,7 @@
     }
   }
 }
+
+.scale-150 {
+  transform: scale(1.5);
+}

--- a/src/app/views/staffs/index.html.erb
+++ b/src/app/views/staffs/index.html.erb
@@ -42,6 +42,7 @@
             <th scope="col">保有スキル</th>
             <th scope="col">雇用区分</th>
             <th scope="col">アクセス権限</th>
+            <th scope="col">選択時非表示</th>
             <th scope="col">更新日</th>
             <th scope="col"></th>
           </tr>
@@ -55,6 +56,9 @@
               <td><%= safe_join(staff.skills.pluck(:name), tag(:br)) %></td>
               <td><%= staff.employment_type_name %></td>
               <td><%= staff.role.name %></td>
+              <td>
+                <input type="checkbox" class="scale-150 cursor-not-allow" onclick='return false;' <%= staff.hidden ? 'checked' : '' %>>
+              </td>
               <td><%= staff.updated_at.strftime('%Y/%m/%d') %></td>
               <td><%= link_to "詳細へ", staff_path(staff.id) %></td>
             </tr>

--- a/src/app/views/staffs/index.html.erb
+++ b/src/app/views/staffs/index.html.erb
@@ -57,7 +57,7 @@
               <td><%= staff.employment_type_name %></td>
               <td><%= staff.role.name %></td>
               <td>
-                <input type="checkbox" class="scale-150 cursor-not-allow" onclick='return false;' <%= staff.hidden ? 'checked' : '' %>>
+                <input type="checkbox" class="scale-150 poin" disabled <%= staff.hidden ? 'checked' : '' %>>
               </td>
               <td><%= staff.updated_at.strftime('%Y/%m/%d') %></td>
               <td><%= link_to "詳細へ", staff_path(staff.id) %></td>


### PR DESCRIPTION
# 概要
スタッフ管理に選択時非表示のチェックボックス追加

<img width="458" alt="スクリーンショット 2021-04-17 22 46 02" src="https://user-images.githubusercontent.com/40763821/115115317-c4470480-9fce-11eb-9eae-0db263cd60a9.png">

