### PR TITLE
ログイン者がhiddenの場合shiftで落ちる問題修正

### DIFF
--- a/src/app/controllers/shifts_controller.rb
+++ b/src/app/controllers/shifts_controller.rb
@@ -14,6 +14,7 @@ class ShiftsController < ApplicationController
       ).where_months(@search_params[:month])
       .group_by { |shift| shift.date.strftime('%Y-%m-%d') }
 
+    @staff = Staff.find(@search_params[:staff_id])
     @start_date, @end_date = Shift.get_month_range(@search_params[:month])
     @store = Store.find(@search_params[:store_id])
   end
@@ -23,8 +24,7 @@ class ShiftsController < ApplicationController
       create_shifts
       delete_shifts if delete_shift_ids.present?
     end
-
-    redirect_to action: :index
+    redirect_back fallback_location: {action: :index}
   end
 
   protected
@@ -72,11 +72,11 @@ class ShiftsController < ApplicationController
       search_month = Date.new(params["month(1i)"].to_i, params["month(2i)"].to_i)
     end
 
-    @staff = !current_staff.hidden ? current_staff : Staff.exclude_hidden.first
+    staff = !current_staff.hidden ? current_staff : Staff.exclude_hidden.first
 
     return {
-      staff_id: params[:staff_id] || @staff.id,
-      store_id: params[:store_id] || @staff.stores.first.id,
+      staff_id: params[:staff_id] || staff.id,
+      store_id: params[:store_id] || staff.stores.first.id,
       month: search_month
     }
   end

--- a/src/app/controllers/shifts_controller.rb
+++ b/src/app/controllers/shifts_controller.rb
@@ -14,9 +14,10 @@ class ShiftsController < ApplicationController
       ).where_months(@search_params[:month])
       .group_by { |shift| shift.date.strftime('%Y-%m-%d') }
 
-    @staff = Staff.find(@search_params[:staff_id])
     @start_date, @end_date = Shift.get_month_range(@search_params[:month])
     @store = Store.find(@search_params[:store_id])
+    @staff = Staff.exclude_hidden.find_by(@search_params[:staff_id])
+    redirect_to action: :index if @staff.nil?
   end
 
   def updates

--- a/src/app/controllers/shifts_controller.rb
+++ b/src/app/controllers/shifts_controller.rb
@@ -16,8 +16,6 @@ class ShiftsController < ApplicationController
 
     @start_date, @end_date = Shift.get_month_range(@search_params[:month])
     @store = Store.find(@search_params[:store_id])
-    @staff = Staff.exclude_hidden.find_by(id: @search_params[:staff_id])
-    @staff = Staff.exclude_hidden.first() if @staff.nil?
   end
 
   def updates
@@ -74,9 +72,11 @@ class ShiftsController < ApplicationController
       search_month = Date.new(params["month(1i)"].to_i, params["month(2i)"].to_i)
     end
 
+    @staff = !current_staff.hidden ? current_staff : Staff.exclude_hidden.first
+
     return {
-      staff_id: params[:staff_id] || current_staff.id,
-      store_id: params[:store_id] || current_staff.stores.first.id,
+      staff_id: params[:staff_id] || @staff.id,
+      store_id: params[:store_id] || @staff.stores.first.id,
       month: search_month
     }
   end

--- a/src/app/controllers/shifts_controller.rb
+++ b/src/app/controllers/shifts_controller.rb
@@ -16,7 +16,8 @@ class ShiftsController < ApplicationController
 
     @start_date, @end_date = Shift.get_month_range(@search_params[:month])
     @store = Store.find(@search_params[:store_id])
-    @staff = Staff.exclude_hidden.find(@search_params[:staff_id])
+    @staff = Staff.exclude_hidden.find_by(id: @search_params[:staff_id])
+    @staff = Staff.exclude_hidden.first() if @staff.nil?
   end
 
   def updates


### PR DESCRIPTION
# 概要
初期表示の際やstaff_idにhiddenの指定があったら落ちる
current _staffがhiddenの場合挙動がおかしくなる

# 対応
current_staffがhiddenかで条件分岐する

# 変更点
- hiddenのスタッフがシフトを見た際、落ちないようになり、hiddenではないユーザのを表示
- urlにstaff_idを直うちしてhiddenだった場合落ちていたが、hiddenではないユーザのを表示
- 更新後に更新したスタッフのシフトを表示