### PR TITLE
パスワードのバリデーションを修正

### DIFF
--- a/src/.rubocop_todo.yml
+++ b/src/.rubocop_todo.yml
@@ -233,6 +233,7 @@ Style/ClassAndModuleChildren:
     - 'app/controllers/concerns/reservation_searchable.rb'
     - 'app/controllers/concerns/token_authenticable.rb'
     - 'app/controllers/customers/duplicate_controller.rb'
+    - 'app/controllers/customers/csv_controller.rb'
     - 'app/controllers/staffs/sessions_controller.rb'
     - 'test/test_helper.rb'
 

--- a/src/app/controllers/customers/csv_controller.rb
+++ b/src/app/controllers/customers/csv_controller.rb
@@ -1,5 +1,4 @@
 class Customers::CsvController < ApplicationController
-
   def index
     filename = 'customers_' + Date.current.strftime("%Y%m%d")
 

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -6,6 +6,8 @@ class Customer < ApplicationRecord
   include PaginationModule
   include SquareCustomerModule
 
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
+
   belongs_to(
     :first_visit_store,
     optional: true,
@@ -38,7 +40,8 @@ class Customer < ApplicationRecord
   after_save :save_visit_stores
 
   validates :tel, numericality: { allow_blank: true }, length: { in: 9..15 }
-  validates :password, presence: true, if: :should_validate_password?
+  validates :password, presence: true, length: { minimum: 8 },
+                       format: { with: VALID_PASSWORD_REGEX }, if: :should_validate_password?
   validates :email, uniqueness: true, unless: :common_email?
   validates :visit_store_ids, allow_nil: true, visit_store: true
 

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -142,7 +142,7 @@ class Customer < ApplicationRecord
   # 会員かつ、メールアドレスが変更された場合、パスワードをチェックする
   def should_validate_password?
     # nilからの変更は、changed? === trueとして認識されないため、下記の様に確認
-    return self.member? && self.email != self.email_was
+    return (self.member? && self.email != self.email_was) || !self.common_email?
   end
 
   def sync_provider

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -142,7 +142,7 @@ class Customer < ApplicationRecord
   # 会員かつ、メールアドレスが変更された場合、パスワードをチェックする
   def should_validate_password?
     # nilからの変更は、changed? === trueとして認識されないため、下記の様に確認
-    return (self.member? && self.email != self.email_was) || !self.common_email?
+    return (self.member? && self.email != self.email_was) || (!self.common_email? && self.new_record?)
   end
 
   def sync_provider

--- a/src/test/controllers/api/customers/registrations_controller_test.rb
+++ b/src/test/controllers/api/customers/registrations_controller_test.rb
@@ -15,7 +15,7 @@ class ApiRegistrationsControllerTest < ActionDispatch::IntegrationTest
       last_visit_store_id: 1,
       can_receive_mail: 1,
       email: Faker::Internet.email,
-      password: 'test123'
+      password: 'test1234'
     }
   end
 


### PR DESCRIPTION
パスワードのバリデーションを修正しました。
メールアドレスが、 `common.mail@olivebodycare.healthcare`  の時
管理画面から顧客登録する時にバリデーションが走らないようにしました。