### PR TITLE
本番環境にて、顧客統合機能の挙動がおかしいので修正

### DIFF
--- a/src/app/controllers/customer_integrations_controller.rb
+++ b/src/app/controllers/customer_integrations_controller.rb
@@ -15,7 +15,8 @@ class CustomerIntegrationsController < ApplicationController
   end
 
   def integrate
-    @customer.integrate!(params[:integration_customer_id])
+    integrate_customer = Customer.find(params[:integration_customer_id])
+    @customer.integrate!(integrate_customer)
     redirect_to customers_path, notice: '顧客統合が完了しました。'
   end
 

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -152,13 +152,11 @@ class Customer < ApplicationRecord
     sorted + self.attributes.except('id', 'first_name', 'last_name', 'first_kana', 'last_kana').values
   end
 
-  def integrate!(integrate_customer_id)
-    integrate_customer = self.class.find(integrate_customer_id)
-
+  def integrate!(integrate_customer)
     transaction do
-      write_integrate_values(integrate_customer)
+      self.write_integrate_values(integrate_customer)
 
-      save!(validate: false)
+      self.save!(validate: false)
 
       # 予約情報と経過記録情報の紐付けを変更する
       integrate_customer.reservations.each do |reservation|


### PR DESCRIPTION
## 挙動について
- 顧客統合を実行したにも関わらず、実データに影響がない
    - レスポンス自体は、成功している
- cloudwatchのログを見るは下記になる
    - 監査ログのデータは正しく保存されている
    - 顧客情報は更新日だけ保存されている
- レスポンスが成功している理由としては、保存処理自体は成功しているためと思われる

## 対応内容
- self.class.findの実装をやめる
    - コントローラで統合元ユーザーを取得するように修正
- 本番環境での検証は実施済み

### バグ原因の考察
- active_recordではクラスとobjectの境目が曖昧である
    - クラス自体もObjectとしてロードされているため
        - クラスインスタンスとして表現される
        - Customer.whereなどのクエリなどを保持している
- 挙動として、self.class.findが影響しているものと推測
    - クラスインスタンスと紐づく実レコードが変わった（selfの参照先が変わった？）
        - 実際として、self.class.findはselfの内容を変えるものである
- とはいえ、検証環境では動作した理由は不明である