### PR TITLE
M1Macへの対応とstaff_seedsファイルのPWに数字を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   rails:
+    platform: 'linux/amd64'
     build: .
     environment:
       TZ: "Japan"
@@ -17,6 +18,7 @@ services:
     stdin_open: true
 
   mysql:
+    platform: 'linux/amd64'
     image: mysql:5.7
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     container_name: "olive-mysql"

--- a/src/config/environments/development.rb
+++ b/src/config/environments/development.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   config.action_mailer.default_url_options = {
     host: 'localhost',

--- a/src/db/seeds/test/20190602_staff_seeds.rb
+++ b/src/db/seeds/test/20190602_staff_seeds.rb
@@ -5,7 +5,7 @@
 # 1：赤川（2店舗所属、柔道整復師＆鍼灸師、正社員）
 Staff.where(id: 1).first_or_create!(
   login: 'akagawa',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '赤川',
   first_kana: 'ハナコ',
@@ -25,7 +25,7 @@ Staff.where(id: 1).first_or_create!(
 # 2：田坂（2店舗所属、柔道整復師＆鍼灸師、正社員）
 Staff.where(id: 2).first_or_create!(
   login: 'tasaka',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '田坂',
   first_kana: 'ハナコ',
@@ -45,7 +45,7 @@ Staff.where(id: 2).first_or_create!(
 # 3：鈴木（オリーヴ所属、柔道整復師、正社員）
 Staff.where(id: 3).first_or_create!(
   login: 'suzuki',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '鈴木',
   first_kana: 'ハナコ',
@@ -59,7 +59,7 @@ Staff.where(id: 3).first_or_create!(
 # 4：國分（オリーヴ所属、柔道整復師、バイト）
 Staff.where(id: 4).first_or_create!(
   login: 'kokubun',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '國分',
   first_kana: 'ハナコ',
@@ -73,7 +73,7 @@ Staff.where(id: 4).first_or_create!(
 # 5：金森（オリーヴ所属、柔道整復師＆鍼灸師、バイト）
 Staff.where(id: 5).first_or_create!(
   login: 'kanamori',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '金森',
   first_kana: 'ハナコ',
@@ -90,7 +90,7 @@ Staff.where(id: 5).first_or_create!(
 # 6：牧野（オリーヴ所属、柔道整復師、正社員）
 Staff.where(id: 6).first_or_create!(
   login: 'makino',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '牧野',
   first_kana: 'ハナコ',
@@ -104,7 +104,7 @@ Staff.where(id: 6).first_or_create!(
 # 7：水谷（オリーヴ所属、柔道整復師＆鍼灸師、正社員）
 Staff.where(id: 7).first_or_create!(
   login: 'mizutani',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '水谷',
   first_kana: 'ハナコ',
@@ -121,7 +121,7 @@ Staff.where(id: 7).first_or_create!(
 # 8：鎌田（オリーヴ所属、柔道整復師、バイト）
 Staff.where(id: 8).first_or_create!(
   login: 'kamata',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '鎌田',
   first_kana: 'ハナコ',
@@ -135,7 +135,7 @@ Staff.where(id: 8).first_or_create!(
 # 9：テストスタッフ（管理者権限、2店舗所属、柔道整復師＆鍼灸師、契約社員）
 Staff.where(id: 9).first_or_create!(
   login: 'test1',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: '管理者',
   first_kana: 'ハナコ',
@@ -155,7 +155,7 @@ Staff.where(id: 9).first_or_create!(
 # 10：テストスタッフ（スタッフ権限、2店舗所属、柔道整復師＆鍼灸師、契約社員）
 Staff.where(id: 10).first_or_create!(
   login: 'test2',
-  password: 'password',
+  password: 'password1',
   first_name: '花子',
   last_name: 'スタッフ',
   first_kana: 'ハナコ',


### PR DESCRIPTION
・こちらの記事を参考にdocker-compose.ymlを変更
https://qiita.com/prkrsign890/items/10ecb57e0387a673b3a2

・src/config/environments/development.rbの63行目を以下に書き換え
config.file_watcher = ActiveSupport::FileUpdateChecker

・スタッフPWが数字必須になった為、seedsファイルにも追記

・.envファイルが無かった為、.env.exampleをコピーしsrc配下に作成